### PR TITLE
Fix threads Out of Sync Issue

### DIFF
--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -71,7 +71,11 @@ function getStorageJSON(key) {
   const value = getLocal(key);
 
   try {
-    return JSON.parse(value);
+    if (value) {
+      return JSON.parse(value);
+    } else {
+      return null;
+    }
   } catch (e) {
     console.error(`error: attempted to parse value '${value}' from key '${key}'. got error: ${e}`);
 

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -15,9 +15,6 @@ export async function getNewThread() {
 export async function getThread() {
   var thread = getStoredActiveThread();
 
-  console.log("initial thread: ");
-  console.dir(thread);
-
   let isValidThreadId = false;
   if (thread !== null) {
     isValidThreadId = await validThread(thread.id);
@@ -29,17 +26,11 @@ export async function getThread() {
     setThread(thread);
   }
 
-  console.log("thread: ");
-  console.dir(thread);
-
   var threads = getStoredThreads();
-  console.log("threads: ");
-  console.dir(threads);
 
   const threadInThreads = threads.filter((t) => t.id == thread.id).length > 0;
 
   if (threads && !threadInThreads) {
-    console.log("thread not in threads");
     threads.unshift(thread);
     setThreads(threads);
 
@@ -48,7 +39,6 @@ export async function getThread() {
     setThreads(threads);
   }
 
-  console.log(thread);
   return thread;
 }
 

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -6,34 +6,50 @@ export async function getNewThread() {
 
   if (new_id) {
     const new_name = "New Chat";
-    return {name: new_name, id: new_id};
+    return {name: new_name, id: new_id, length: 0};
   }
 
   return null;
 }
 
 export async function getThread() {
-  const thread = getStoredActiveThread();
+  var thread = getStoredActiveThread();
+
+  console.log("initial thread: ");
+  console.dir(thread);
 
   let isValidThreadId = false;
   if (thread !== null) {
     isValidThreadId = await validThread(thread.id);
   }
 
-  if (isValidThreadId) {
-    return thread;
+  if (thread === null || !isValidThreadId) {
+    thread = await getNewThread();
+
+    setThread(thread);
   }
 
-  if (thread === null) {
-    const new_thread = await getNewThread();
+  console.log("thread: ");
+  console.dir(thread);
 
-    setThreads([new_thread]);
-    setThread(new_thread);
+  var threads = getStoredThreads();
+  console.log("threads: ");
+  console.dir(threads);
 
-    return new_thread;
+  const threadInThreads = threads.filter((t) => t.id == thread.id).length > 0;
+
+  if (threads && !threadInThreads) {
+    console.log("thread not in threads");
+    threads.unshift(thread);
+    setThreads(threads);
+
+  } else if (!threads){
+    threads = [thread];
+    setThreads(threads);
   }
 
-  return null;
+  console.log(thread);
+  return thread;
 }
 
 export async function setThread(thread) {


### PR DESCRIPTION
# Fix threads Out of Sync Issue
## Issue
- The currently active thread was not show in the sidebar list of threads
- Because of this, it was not shown as selected or shown in the navbar

## Fix
- When `getThread()` is called, it now checks if the retrieved thread is in the threads list.
  - If not, add it to the front of threads list and store