### PR TITLE
Fix Mobile PWA View in Landscape

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -407,6 +407,8 @@
 <style>
     #content-container {
       height: calc(100% - 3rem);
+      padding-right: env(safe-area-inset-right);
+      padding-left: env(safe-area-inset-left);
     }
 
     #chat-container {

--- a/src/components/Hamburger.svelte
+++ b/src/components/Hamburger.svelte
@@ -20,7 +20,6 @@
     .container {
         width: 2em;
         height: 2em;
-        margin-right: 4.5em;
     }
 
     .menu:hover {

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -68,7 +68,7 @@
     border-bottom: 1px solid rgb(180, 180, 180);
     height: 10em;
     margin-top: -7em;
-    padding-top: 7.5em;
+    padding: 7.5em env(safe-area-inset-right) 0 env(safe-area-inset-left);
   }
   button {
     width: 50%;

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -68,7 +68,7 @@
     border-bottom: 1px solid rgb(180, 180, 180);
     height: 10em;
     margin-top: -7em;
-    padding: 7.5em env(safe-area-inset-right) 0 env(safe-area-inset-left);
+    padding: 7.5em env(safe-area-inset-right) 0.5em env(safe-area-inset-left);
   }
   button {
     width: 50%;

--- a/src/components/SlideButtonReveal.svelte
+++ b/src/components/SlideButtonReveal.svelte
@@ -172,6 +172,8 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         cursor: pointer;
+        padding-right: env(safe-area-inset-right);
+        padding-left: env(safe-area-inset-left);
     }
 
     .reveal {

--- a/src/components/SlideButtonReveal.svelte
+++ b/src/components/SlideButtonReveal.svelte
@@ -172,7 +172,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         cursor: pointer;
-        padding-right: env(safe-area-inset-right);
         padding-left: env(safe-area-inset-left);
     }
 


### PR DESCRIPTION
# Fix Mobile PWA View in Landscape
- Notch and curved corners were cutting off nav, messages, and chats in sidebar
- Updated padding to account for left and right "safe areas"

## Changes
- Add padding within Navbar to account for left and right "safe-area" (notch).
- Add padding in content container to account for left and right "safe-area" (notch).
- Add padding in SlideButtonReveal to account for left "safe-area" (notch)

## Screenshots
<img width="884" alt="moible-fix-notch-sidebar" src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/2d3fb3c7-954b-4744-a570-8ed437912130">


<img width="884" alt="mobile-fix-notch-chat" src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/4aea57f5-5853-4434-9cbf-ad8b2fa67f2c">
