### PR TITLE
Thread Error Handling

### DIFF
--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -87,7 +87,7 @@ async function genImage(params, threadId, addMessageCallback) {
   return "The image has been inserted into the chat. Respond with a very short question bring this back into this process. DO NOT REPLY WITH AN IMAGE, MARKDOWN, OR ANYTHING OTHER THAN A SHORT QUESTION.";
 }
 
-async function imageToText(params) {
+async function imageToText(params, threadId) {
   let imageParams = JSON.parse(params);
 
   if ("parameters" in imageParams) {
@@ -96,7 +96,7 @@ async function imageToText(params) {
 
   let prompt = imageParams.prompt
 
-  let text = await getImageToText(prompt);
+  let text = await getImageToText(prompt, threadId);
 
   return text;
 }
@@ -169,7 +169,7 @@ export async function callFunc(functionDetails, context) {
     tmp = await getFileType(functionDetails.arguments);
   }
   else if (functionDetails.name == "image_to_text") {
-    tmp = await imageToText(functionDetails.arguments);
+    tmp = await imageToText(functionDetails.arguments, context.lastMessageId);
   }
   return tmp;
 }

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -298,6 +298,37 @@ export async function getDalleImageGeneration(prompt, image_size = null, image_q
   }
 }
 
+export async function cancelThreadRun(threadId, runId) {
+  const url = `https://api.openai.com/v1/threads/${threadId}/runs/${runId}/cancel`;
+
+  if (!openaiKey) {
+    throw new Error('openai key not set. cannot validate thread.');
+  }
+
+  if (!threadId) {
+    return [];
+  }
+
+  const method = 'POST';
+  const headers = {
+    'Authorization': 'Bearer ' + openaiKey,
+    'OpenAI-Beta': 'assistants=v1'
+  };
+
+  const request = {
+    method,
+    headers
+  }
+
+  const response = await fetch(url, request);
+
+  const r = await response.json();
+  if (r.error && r.error.type === 'invalid_request_error') {
+    console.error(r.error);
+    return [];
+  }
+}
+
 export async function getThreadMessages(threadId, limit) {
   const url = `https://api.openai.com/v1/threads/${threadId}/messages?limit=${limit}`;
 

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -435,9 +435,9 @@ export async function getImageDescription(base64, prompt) {
   return imageDescription;
 }
 
-export async function getImageToText(prompt) {
+export async function getImageToText(prompt, id) {
 
-  let imageFiles = await getThreadImages()
+  let imageFiles = await getThreadImages(id)
 
   if (imageFiles.length > 0) {
     const imageSource = imageFiles[imageFiles.length - 1]

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -49,8 +49,8 @@ export async function getEmptyThread(emptyLength) {
   return await bidaraDB.getEmptyThread(emptyLength);
 }
 
-export async function getThreadImages() {
-  let files = await getThreadFiles();
+export async function getThreadImages(id) {
+  let files = await bidaraDB.getThreadFiles(id);
 
   let imageFiles = files.filter(file => file.type === "image")
 


### PR DESCRIPTION
# Thread Error Handling
- When an error occurs such that it prevents deep-chat from further interacting with the current message (thread/run), cancel the thread run to allow the user to continue the conversation
- Also fix an image retrieval method causing an error

## Changes
### `AssistantDeepChat.svelte`
- on each response, update the current run id so it can be cancelled when needed
- in `deep-chat` `onError` function, call to cancel thread run

### `openaiUtils.js`
- add `cancelThreadRun` function to be called when cancelling a thread run
- add id parameter to `getImageToText` function to account for thread-sync file changes, which caused an error

### `threadUtils.js`, `bidaraFunctions.js`
- add id parameter to function call and declaration for image file retrieval