### PR TITLE
File link replacements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,6 @@
       let colorTheme = "light";
 
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-        console.log("change theme in index")
         colorTheme = event.matches ? "dark" : "light";
         setCssVars(colorTheme);
       });

--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -124,14 +124,14 @@ function getFileTypeByName(fileName) {
   return type;
 }
 
-async function getFileType(params) {
+async function getFileType(params, threadId) {
   let fileTypeParams = JSON.parse(params);
 
   if ("parameters" in fileTypeParams) {
     fileTypeParams = fileTypeParams.parameters;
   }
 
-  let files = await getThreadFiles();
+  let files = await getThreadFiles(threadId);
 
   if (files.length < 1) {
     return "No files have been uploaded.";
@@ -166,7 +166,7 @@ export async function callFunc(functionDetails, context) {
     }
   }
   else if (functionDetails.name == "get_file_type") {
-    tmp = await getFileType(functionDetails.arguments);
+    tmp = await getFileType(functionDetails.arguments, context.lastMessageId);
   }
   else if (functionDetails.name == "image_to_text") {
     tmp = await imageToText(functionDetails.arguments, context.lastMessageId);

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -74,6 +74,7 @@
       let name = file?.name ? file.name : "";
 
       return {
+        thread_id: threadId,
         type,
         name,
         src,
@@ -81,6 +82,7 @@
         attached,
         role,
         text,
+        replaceText: null,
       }
     });
 

--- a/src/utils/bidaraDB.js
+++ b/src/utils/bidaraDB.js
@@ -1,16 +1,20 @@
 import * as dbUtils from "./indexDBUtils"
 
 const CHAT_STORE_NAME = "threads";
+const FILE_STORE_NAME = "files";
 const ACTIVE_STATUS = 1;
 const INACTIVE_STATUS = 0;
 
 const BIDARA_DB_CONFIG = { 
 	name: "bidara", 
-	version: 1,
+	version: 3,
 	stores: [ 
 		{ 
 			name: CHAT_STORE_NAME, 
-			primaryKey: "id",
+			primaryKey: {
+				key: "id",
+				autoIncrement: false
+			},
 			indices: [
 				{
 					name: "active",
@@ -41,7 +45,23 @@ const BIDARA_DB_CONFIG = {
 					}
 				}
 			]
-		} 
+		},
+		{
+			name: FILE_STORE_NAME,
+			primaryKey: {
+				key: "id",
+				autoIncrement: true
+			},
+			indices : [
+				{
+					name: "thread",
+					property: "thread_id",
+					options: {
+						unique: false
+					}
+				}
+			]
+		}
 	] 
 }
 
@@ -81,9 +101,9 @@ export async function getMostRecentlyUpdatedThread() {
 	return await dbUtils.readFirstByIndex(BIDARA_DB, CHAT_STORE_NAME, "updated_time", true);
 }
 
-export async function getThreadFiles(id) {
-	const thread = await getThreadById(id);
-	const files = thread?.files;
+export async function getThreadFiles(threadId) {
+	const files = await dbUtils.readByProperty(BIDARA_DB, FILE_STORE_NAME, "thread_id", threadId);
+	console.log(files);
 
 	if (!files) {
 		return [];
@@ -129,7 +149,7 @@ export async function pushMessageToId(id, message) {
 
 export async function pushFileToId(id, file) {
 	// { index: int, file: b64Data }
-	await dbUtils.pushToListProperty(BIDARA_DB, CHAT_STORE_NAME, id, "files", file)
+	await dbUtils.write(BIDARA_DB, FILE_STORE_NAME, file);
 }
 
 export async function setThread(thread) {

--- a/src/utils/bidaraDB.js
+++ b/src/utils/bidaraDB.js
@@ -103,7 +103,6 @@ export async function getMostRecentlyUpdatedThread() {
 
 export async function getThreadFiles(threadId) {
 	const files = await dbUtils.readByProperty(BIDARA_DB, FILE_STORE_NAME, "thread_id", threadId);
-	console.log(files);
 
 	if (!files) {
 		return [];

--- a/src/utils/indexDBUtils.js
+++ b/src/utils/indexDBUtils.js
@@ -46,7 +46,7 @@ function createStore(event, db, name, primaryKey, indices) {
 		db.deleteObjectStore(name);
 	}
 
-	const objectStore = db.createObjectStore(name, { keyPath: primaryKey });
+	const objectStore = db.createObjectStore(name, { keyPath: primaryKey.key, autoIncrement: primaryKey.autoIncrement });
 
 	if (indices) {
 		indices.forEach((index) => {
@@ -177,11 +177,12 @@ export async function readByProperty(db, storeName, propertyKey, propertyValue, 
 			reject(error); 
 			return;
 		}
+
+		if (typeof callback === 'function') {
+			callback(transaction);
+		}
 	});
 
-	if (typeof callback === 'function') {
-		callback(transaction);
-	}
 }
 
 export async function readFirstByIndex(db, storeName, storeIndex, reversed, transaction = null, callback = null) {

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -332,6 +332,51 @@ export async function getThreadMessages(threadId, limit) {
   return r.data
 }
 
+export async function getFileContent(fileId) {
+  const url = `https://api.openai.com/v1/files/${fileId}/content`;
+
+  if (!openaiKey) {
+    throw new Error('openai key not set. cannot validate thread.');
+  }
+
+  const method = 'GET';
+  const headers = {
+    'Authorization': 'Bearer ' + openaiKey,
+    'Content-Type': 'application/json',
+  };
+
+  const request = {
+    method,
+    headers
+  }
+
+  const response = await fetch(url, request);
+
+  if (!response.ok) {
+    console.error("Error with response: ");
+    console.error(response);
+    return "";
+  }
+
+  return response.blob();
+}
+
+export async function getFileSrc(fileId) {
+  const blob = await getFileContent(fileId);
+  const src = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onload = (event) => {
+      resolve(event.target.result);
+    }
+    reader.onerror = (event) => {
+      reject("error reading file");
+    }
+  })
+
+  return src;
+}
+
 export async function getChatCompletion(model, messages, tokenLimit) {
   if (!openaiKey) {
     throw new Error('openai key not set. cannot validate thread.');

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -147,8 +147,11 @@ function equivalentMessages(message, threadMessage) {
   const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
   const threadFileLinkRegEx = /\]\(sandbox:[\S]+\)/igm;
 
-  const messagesMsg = findReplaceListRegEx(message, [msgFileLinkRegEx, threadFileLinkRegEx], [']()',']()'])
-  const threadsMsg = findReplaceListRegEx(threadMessage, [msgFileLinkRegEx, threadFileLinkRegEx], [']()',']()'])
+  const regEx = [ msgFileLinkRegEx, threadFileLinkRegEx ];
+  const replacements = [ ']()', ']()'];
+
+  const messagesMsg = findReplaceListRegEx(message, regEx, replacements)
+  const threadsMsg = findReplaceListRegEx(threadMessage, regEx, replacements)
 
   return messagesMsg === threadsMsg;
 }
@@ -206,8 +209,8 @@ function clearNullChats(messages) {
 }
 
 async function replaceThreadFiles(threadMessages) {
-  const withFiles = await Promise.all(threadMessages.map(async (message, i) => {
-    const content = await Promise.all(message.content.map(async (content, j) => {
+  const withFiles = await Promise.all(threadMessages.map(async (message) => {
+    const content = await Promise.all(message.content.map(async (content) => {
       if (content.type !== "text") {
         return content;
       }

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -130,9 +130,6 @@ export async function syncThreadFiles(threadId, messages, files) {
 
     while (file.text && !equivalentMessages(file?.text, messages[file.index]?.text)) {
       file.index = file.index + 1;
-      console.log(file.index);
-      console.log(file.text);
-      console.log(messages[file.index]?.text);
     }
 
     if (messages[file.index].files) {

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -6,7 +6,7 @@ async function createNewThread() {
 
   if (new_id) {
     const new_name = "New Chat";
-    return {name: new_name, id: new_id, length: 0, files: [], active: true};
+    return {name: new_name, id: new_id, length: 0, active: true};
   }
 
   return null;
@@ -50,7 +50,7 @@ export async function getEmptyThread(emptyLength) {
 }
 
 export async function getThreadImages(id) {
-  let files = await bidaraDB.getThreadFiles(id);
+  let files = await getThreadFiles(id);
 
   let imageFiles = files.filter(file => file.type === "image")
 
@@ -59,10 +59,10 @@ export async function getThreadImages(id) {
   return imageSources 
 }
 
-export async function getThreadFiles() {
-  let thread = await bidaraDB.getActiveThread();
+export async function getThreadFiles(id) {
+  const files = await bidaraDB.getThreadFiles(id);
 
-  return thread.files;
+  return files;
 }
 
 export async function setActiveThread(threadId) {
@@ -99,9 +99,7 @@ export async function pushFiles(threadId, files) {
   })
 }
 
-export async function syncThreadFiles(threadId, messages) {
-  const files = await bidaraDB.getThreadFiles(threadId);
-
+export async function syncThreadFiles(threadId, messages, files) {
   if (files.length <= 0) {
     return messages;
   }
@@ -110,6 +108,10 @@ export async function syncThreadFiles(threadId, messages) {
   const insertedFiles = files.filter(file => !file.attached);
 
   insertedFiles.forEach(file => {
+    if (!file.index || file.index === -1) {
+      return;
+    }
+
     const fileInsert = { src: file.src, type: file.type, ref: {} }
     if (file.name) {
       fileInsert.name = file.name
@@ -120,17 +122,17 @@ export async function syncThreadFiles(threadId, messages) {
   })
 
   attachedFiles.forEach(file => {
+
     const fileInsert = { src: file.src, type: file.type, ref: {} }
     if (file.name) {
       fileInsert.name = file.name
     }
 
     while (file.text && !equivalentMessages(file?.text, messages[file.index]?.text)) {
-      file.index += 1;
-    }
-
-    if (file.text) {
-      messages[file.index].text = file.text;
+      file.index = file.index + 1;
+      console.log(file.index);
+      console.log(file.text);
+      console.log(messages[file.index]?.text);
     }
 
     if (messages[file.index].files) {
@@ -176,10 +178,22 @@ function findReplaceRegEx(string, regex, replacement) {
   const matches = (string.match(regex) || [])
 
   matches.forEach(match => {
-    string = string.replace(match, replacement)
+    string = string.replaceAll(match, replacement)
   })
 
   return string
+}
+
+function getFileNameFromLink(link) {
+  const regex = /^sandbox:\/mnt\/data\/(.*)$/;
+
+  const matches = (link.match(regex) || []);
+
+  if (matches.length >= 2) {
+    return matches[1];
+  }
+
+  return "";
 }
 
 function convertThreadMessagesToMessages(threadMessages) {
@@ -208,7 +222,9 @@ function clearNullChats(messages) {
   return messages.filter(msg => msg.text !== null || msg.files );
 }
 
-async function replaceThreadFiles(threadMessages) {
+async function replaceThreadFiles(threadId, threadMessages, files) {
+  const replaceFiles = files.filter(file => file.thread_id === threadId && files.replaceText !== null);
+
   const withFiles = await Promise.all(threadMessages.map(async (message) => {
     const content = await Promise.all(message.content.map(async (content) => {
       if (content.type !== "text") {
@@ -218,22 +234,51 @@ async function replaceThreadFiles(threadMessages) {
       if (!content.text?.annotations || content.text?.annotations?.length < 1) {
         return content;
       }
+      const newFiles = [];
 
       const replacements = await Promise.all(content.text.annotations.map(async (annotation) => {
         if (annotation.type !== "file_path" || !annotation?.file_path?.file_id || annotation.text.substring(0,7) !== "sandbox") {
           return {};
         }
 
+        const existingReplacement = replaceFiles.filter(file => file.replaceText === annotation.text);
+
+        if (existingReplacement.length > 0 && existingReplacement[0].src) {
+          return { link: annotation.text, src: existingReplacement[0].src };
+        }
+
         const fileSrc = await getFileSrc(annotation.file_path.file_id);
+
+        const fileName = getFileNameFromLink(annotation.text);
+
+        const newFile = {
+          thread_id: threadId,
+          type: "any",
+          name: fileName,
+          src: fileSrc,
+          index: null,
+          attached: false,
+          role: message.role,
+          text: null,
+          replaceText: annotation.text,
+        }
+
+        newFiles.push(newFile);
 
         return { link: annotation.text, src: fileSrc };
       }));
 
-      console.log(replacements);
-
       replacements.forEach((replacement) => {
         content.text.value = content.text.value.replaceAll(replacement.link, replacement.src);
       })
+
+      newFiles.forEach(async (newFile) => {
+        if (content.text.value) {
+          newFile.text = content.text.value;
+        }
+
+        await pushFile(threadId, newFile);
+      });
 
       return content;
     }));
@@ -246,13 +291,16 @@ async function replaceThreadFiles(threadMessages) {
 
 export async function syncMessages(threadId, initialMessages) {
   const rawThreadMessages = await getThreadMessages(threadId, 100);
-  const threadMessagesWithFiles = await replaceThreadFiles(rawThreadMessages);
+  const files = await bidaraDB.getThreadFiles(threadId);
+
+  const threadMessagesWithFiles = await replaceThreadFiles(threadId, rawThreadMessages, files);
+
   const threadMessages = convertThreadMessagesToMessages(threadMessagesWithFiles);
   const fullMessages = initialMessages.concat(threadMessages);
 
   const messages = clearNullChats(fullMessages);
 
-  const syncedMessages = await syncThreadFiles(threadId, messages);
+  const syncedMessages = await syncThreadFiles(threadId, messages, files);
 
   return syncedMessages;
 }


### PR DESCRIPTION
# File Link Replacements
- replace links to assistant's sandbox with links to data
- store replacements to avoid future requests for data

## Changes
### `bidaraDB.js`
- add new db store for files

### `openaiUtils.js`
- add functions for retrieving file source data from OpenAI by file_id

### `threadUtils.js`
- add `replaceThreadFileLinks` function which will replace file links to sandbox with file links to data sources
  - will also store data for future reference *in file links*, so not always necessary to request openai

## Problems with this solution
Though this fixes the problem of file links returned by assistants linking to the sandbox, which is unusable, I'm not convinced this is the best solution. I believe the issues are not necessarily in the result, but in the maintainability of the implementation. 

I do think that it's good enough to go to prod for now for the sake of fixing links, but there are some issues:

### Files stored multiple times
- files are stored per reference to the file when returned with a file_id rather than just a link

#### Reason
- Files in different places may have the same file data, but other info that is very different  (to have multiple indexes, can be attached or not attached to messages, can have replacement text or not)
- Files do not have one common value that can be used as a primary key to identify individual files

### Separate handling of file links in text versus file attachments in deep-chat
- handles text replacement of file links in thread text, then goes through again to add in file attachments/inserted files

#### Reason
- have largely different flows and work on different data (threads versus deep-chat messages)

I have some ideas for how to fix these issues, but they require further consideration before committing to. Getting file links fixed in the live version is worth fixing rather than continuing to wait on a relatively better solution that achieves the same results.