### PR TITLE
Export Markdown

### DIFF
--- a/src/components/ExportMarkdown.svelte
+++ b/src/components/ExportMarkdown.svelte
@@ -8,15 +8,32 @@
 		return messages;
 	}
 
+	function findReplaceRegEx(string, regex, replacement) {
+
+		if (!string) {
+			return string;
+		}
+
+		const matches = (string.match(regex) || [])
+
+		matches.forEach(match => {
+			string = string.replace(match, replacement)
+		})
+
+		return string
+	}
+
 	function getMessageAsMarkdown(author, text, files) {
+		const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
+		text = findReplaceRegEx(text, msgFileLinkRegEx, '](Removed file source because it exceeded limit.)')
+
 		if (!files || files.length < 1) {
 			return `## ${author}\n ${text}\n\n`
 		}
 
-
 		let fileContent = ""
 		files.forEach(file => {
-			if (file.src && file.src.length > 500) {
+			if (file.src && file.src.length > 200) {
 				file.src = "Removed file source because it exceeded limit."
 			}
 

--- a/src/components/ExportMarkdown.svelte
+++ b/src/components/ExportMarkdown.svelte
@@ -1,0 +1,91 @@
+<script>
+	export let chatName;
+
+	function getMessages() {
+		const deepChatRef = document.getElementById("chat-element");
+		const messages = deepChatRef.getMessages();
+
+		return messages;
+	}
+
+	function getMessageAsMarkdown(author, text, files) {
+		if (!files || files.length < 1) {
+			return `## ${author}\n ${text}\n\n`
+		}
+
+
+		let fileContent = ""
+		files.forEach(file => {
+			if (file.src && file.src.length > 500) {
+				file.src = "Removed file source because it exceeded limit."
+			}
+
+			if (file.type === "image") {
+				if (file.name) {
+					fileContent += `[${file.name}](${file.src})`;
+				} else {
+					fileContent += `[image](${file.src})`;
+				}
+
+			} else if (file.name){
+				fileContent += `[${file.name}]`;
+
+			} else {
+				fileContent += "[Unidentified file]";
+			}
+		});
+
+		if (text) {
+			return `## ${author}\n ${text}\n ${fileContent}\n\n`
+		} else {
+			return `## ${author}\n ${fileContent}\n\n`
+		}
+
+	}
+
+	function getMarkdownContent() {
+		let markdownContent = `# ${chatName}\n`
+
+		let messages = getMessages();
+
+		messages.forEach((message) => {
+			const author = message.role
+			const text = message.text
+			const files = message.files
+			const messageMarkdown = getMessageAsMarkdown(author, text, files);
+
+			markdownContent += messageMarkdown
+		})
+
+		return markdownContent;
+	}
+
+	function exportAsMarkdown(){
+		const markdownContent = getMarkdownContent();
+
+		const blob = new Blob([markdownContent], { type: 'text/markdown' })
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.download = `${chatName}.md`
+		a.href = url
+		document.body.appendChild(a)
+		a.click()
+		document.body.removeChild(a)
+	}
+
+
+	function handleExport() {
+		exportAsMarkdown();
+	}
+
+</script>
+
+<button class="w-full h-full p-1 flex justify-between items-center focus:outline-none" on:click={handleExport}>
+	<p>Export to Markdown</p>
+</button>
+
+<style>
+	button:focus-visible {
+		outline: 5px auto -webkit-focus-ring-color; 
+	}
+</style>

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -3,6 +3,7 @@
     import Menu from './Menu.svelte';
     import MenuItem from './MenuItem.svelte';
     import ThemeSwitcher from './ThemeSwitcher.svelte';
+    import ExportMarkdown from './ExportMarkdown.svelte';
 	
     export let sidebar = false
     export let chat_name;
@@ -62,6 +63,7 @@
   {/if}
   <Menu>
     <div class="function-container">
+      <MenuItem><ExportMarkdown bind:chatName={chat_name}/></MenuItem>
       <MenuItem><ThemeSwitcher/></MenuItem>
     </div>
     <div class="info-container">


### PR DESCRIPTION
# Export Markdown
- add menu button to export chat to markdown
- exclude most files from the export due to size of data taking away from the content 
  - Example: images with a "data:application/octet-stream;base64,....." source can be hundreds of characters or even lines (often more). This results in the exported file be mostly unreadable base64 encoded image data rather than the conversation.

## Screenshots
<img width="1110" alt="exportMarkdown" src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/8f35b708-5d4a-48b3-8443-d012c7632c89">


## Changes
### `ExportMarkdown.svelte`
- new button component that handles exporting chat history to a markdown file
- replaces file links with a message saying "Removed file source because it exceeded limit."

### `Navbar.svelte`
- add export to markdown button into menu in the navbar
