### PR TITLE
Export PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "deep-chat": "^1.4.11",
+        "jspdf": "^2.5.1",
         "sirv-cli": "^2.0.0",
         "svelte-agnostic-draggable": "^0.2.0",
         "svelte-touch-to-mouse": "^1.0.0"
@@ -560,6 +561,12 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -673,6 +680,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autolinker": {
       "version": "3.16.2",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
@@ -722,6 +740,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -750,6 +777,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -791,6 +829,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -898,6 +961,17 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/core-js": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
+      "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -952,6 +1026,15 @@
       },
       "engines": {
         "node": ">=4.8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -1039,6 +1122,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.9.tgz",
+      "integrity": "sha512-iHtnxYMotKgOTvxIqq677JsKHvCOkAFqj9x8Mek2zdeHW1XjuFKwjpmZeMaXQRQ8AbJZDbcRz/+r1QhwvFtmQg==",
+      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -1153,6 +1242,11 @@
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -1431,6 +1525,19 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -1774,6 +1881,23 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2075,6 +2199,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
@@ -2135,6 +2265,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/randombytes": {
@@ -2240,6 +2379,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -2603,6 +2751,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string.prototype.padend": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.5.tgz",
@@ -2757,6 +2914,15 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/terser": {
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
@@ -2773,6 +2939,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinydate": {
@@ -2894,6 +3069,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "deep-chat": "^1.4.11",
+    "jspdf": "^2.5.1",
     "sirv-cli": "^2.0.0",
     "svelte-agnostic-draggable": "^0.2.0",
     "svelte-touch-to-mouse": "^1.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,8 @@ export default {
     sourcemap: true,
     format: "iife",
     name: "app",
-    file: "public/build/bundle.js"
+    file: "public/build/bundle.js",
+    inlineDynamicImports: true
   },
   plugins: [
     svelte({

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -317,6 +317,9 @@
     a:visited {
     color: var(--link-visited-color);
     }
+    img {
+      max-width: 100%;
+    }
     ::-webkit-scrollbar {
       width: 8px;
       height: 8px;

--- a/src/components/ExportPdf.svelte
+++ b/src/components/ExportPdf.svelte
@@ -99,7 +99,7 @@
   function getImgNode(src) {
     const node = getNode("img");
     node.src = src;
-    node.style.height = "500px";
+    node.style.maxHeight = "500px";
     return node;
   }
 

--- a/src/components/ExportPdf.svelte
+++ b/src/components/ExportPdf.svelte
@@ -108,15 +108,11 @@
   }
 
   function getNewImgNode(src) {
-    const node = getNewNode("div");
-    node.style.height = "500px";
-
-    const imgNode = getNewNode("img");
-    imgNode.src = src;
-    imgNode.style.maxHeight = "500px";
-    imgNode.style.maxWidth = "500px";
-    imgNode.style.margin = "auto";
-    node.appendChild(imgNode);
+    const node = getNewNode("img");
+    node.src = src;
+    node.style.maxHeight = "500px";
+    node.style.maxWidth = "500px";
+    node.style.margin = "auto";
 
     return node; 
   }

--- a/src/components/ExportPdf.svelte
+++ b/src/components/ExportPdf.svelte
@@ -1,0 +1,215 @@
+<script>
+  import { jsPDF } from "jspdf";
+
+  export let chatName;
+
+  function getMessages() {
+    const deepChatRef = document.getElementById("chat-element");
+    const messages = deepChatRef.getMessages();
+
+    return messages;
+  }
+
+	function findReplaceRegEx(string, regex, replacement) {
+
+		if (!string) {
+			return string;
+		}
+
+		const matches = (string.match(regex) || [])
+
+		matches.forEach(match => {
+			string = string.replace(match, replacement)
+		})
+
+		return string
+	}
+
+  function getMessageHtmlTree(chatName, messages) {
+    const contents = messages.map((message) => {
+			const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
+			message.text = findReplaceRegEx(message.text, msgFileLinkRegEx, '](Removed file source because it exceeded limit.)')
+
+
+      if (!message.files) {
+        return {
+          h2: message.role,
+          p: message.text,
+        }
+      } else {
+        const files = message.files.map(file => { 
+          const src = file.src ? file.src : "no source";
+          const type = file.type ? file.type : "";
+          return { name: file.name, src: src, type: type } 
+        })
+
+        if (message.text) {
+          return {
+            h2: message.role,
+            p: message.text,
+            files: files
+          }
+        } else {
+          return {
+            h2: message.role,
+            files: files
+          }
+        }
+      }
+    })
+
+    const title = {
+      h1: chatName,
+    }
+
+    return {
+      title,
+      contents
+    }
+  }
+
+  function getNode(type, text) {
+    const node = document.createElement(type);
+    if (text) {
+      const textNode = document.createTextNode(text);
+      node.appendChild(textNode);
+    }
+
+    return node;
+  }
+
+  function getH1Node(text) {
+    const node = getNode("h1", text);
+    node.style.fontSize = "3rem";
+    return node;
+  }
+
+  function getH2Node(text) {
+    const node = getNode("h2", text);
+    node.style.fontSize = "2rem";
+    return node;
+  }
+
+  function getPNode(text) {
+    const node = getNode("p", text);
+    node.style.fontSize = "1rem";
+    return node;
+  }
+
+  function getImgNode(src) {
+    const node = getNode("img");
+    node.src = src;
+    node.style.height = "500px";
+    return node;
+  }
+
+  function createTitleNode(title) {
+    const root = getNode("div");
+    root.style.display = "flex";
+    root.style.justifyContent = "space-between";
+    root.style.alignItems = "center";
+
+    const titleNode = getH1Node(title.h1);
+    root.appendChild(titleNode);
+
+    const creditsNode = getPNode("Bidara by NASA PeTaL");
+    root.appendChild(creditsNode);
+
+    return root;
+  }
+
+  function htmlTreeToHtml(tree) {
+    const title = tree.title;
+    const contents = tree.contents;
+
+    const root = getNode("div");
+    root.style.fontSize = "32px";
+
+    const titleNode = createTitleNode(title);
+    root.appendChild(titleNode);
+
+    const contentsNode = getNode("div");
+
+    contents.forEach(content => {
+      const contentNode = getNode("div");
+
+      const roleNode = getH2Node(content.h2);
+      contentNode.appendChild(roleNode);
+
+      if (content.p) {
+        const textNode = getPNode(content.p);
+        contentNode.appendChild(textNode)
+      } 
+
+      if (content.files) {
+        content.files.forEach((file) => {
+          if (file.type === "image") {
+            const breakNode = getNode("br");
+            contentNode.appendChild(breakNode);
+
+            const imgNode = getImgNode(file.src);
+            contentNode.appendChild(imgNode);
+
+          } else if (file.name) {
+            const fileNameNode = getPNode(`(file) : [${file.name}]`);
+            contentNode.appendChild(fileNameNode);
+
+          } else {
+            const fileNameNode = getPNode("(file) : [unnamed file]");
+            contentNode.appendChild(fileNameNode);
+          }
+        })
+      }
+
+      contentsNode.appendChild(contentNode);
+    })
+
+    root.appendChild(contentsNode);
+
+    return root;
+  }
+
+  function htmlToPdf(title, html) {
+    const doc = new jsPDF('p', 'pt', 'a4')
+
+    doc.html(html, {
+      callback: function(doc) {
+        doc.save(`${title}.pdf`);
+      },
+      margin: [20, 20, 20, 20],
+      autoPaging: "text",
+      x: 20,
+      y: 20,
+      width: 500,
+      windowWidth: 675
+    })
+  }
+
+  function exportAsPdf(){
+    const title = chatName;
+    const messages = getMessages();
+
+    const messagesTree = getMessageHtmlTree(title, messages);
+
+    const messagesHtml = htmlTreeToHtml(messagesTree);
+
+    console.log(messagesHtml);
+    htmlToPdf(title, messagesHtml);
+  }
+
+
+  function handleExport() {
+    exportAsPdf();
+  }
+
+</script>
+
+<button class="w-full h-full p-1 flex justify-between items-center focus:outline-none" on:click={handleExport}>
+	<p>Export to PDF</p>
+</button>
+
+<style>
+  button:focus-visible {
+    outline: 5px auto -webkit-focus-ring-color; 
+  }
+</style>

--- a/src/components/ExportPdf.svelte
+++ b/src/components/ExportPdf.svelte
@@ -10,31 +10,32 @@
     return messages;
   }
 
-	function findReplaceRegEx(string, regex, replacement) {
+  function findReplaceRegEx(string, regex, replacement) {
 
-		if (!string) {
-			return string;
-		}
+    if (!string) {
+      return string;
+    }
 
-		const matches = (string.match(regex) || [])
+    const matches = (string.match(regex) || [])
 
-		matches.forEach(match => {
-			string = string.replace(match, replacement)
-		})
+    matches.forEach(match => {
+      string = string.replace(match, replacement)
+    })
 
-		return string
-	}
+    return string
+  }
 
   function getMessageHtmlTree(chatName, messages) {
     const contents = messages.map((message) => {
-			const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
-			message.text = findReplaceRegEx(message.text, msgFileLinkRegEx, '](Removed file source because it exceeded limit.)')
+      const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
+      message.text = findReplaceRegEx(message.text, msgFileLinkRegEx, '](Removed file source because it exceeded limit.)')
 
+      const role = message.role === "ai" ? "Bidara:" : "User:";
 
       if (!message.files) {
         return {
-          h2: message.role,
-          p: message.text,
+          role: role,
+          text: message.text,
         }
       } else {
         const files = message.files.map(file => { 
@@ -45,13 +46,13 @@
 
         if (message.text) {
           return {
-            h2: message.role,
-            p: message.text,
+            role: role,
+            text: message.text,
             files: files
           }
         } else {
           return {
-            h2: message.role,
+            role: role,
             files: files
           }
         }
@@ -59,7 +60,8 @@
     })
 
     const title = {
-      h1: chatName,
+      name: chatName,
+      credits: "Bidara by NASA PeTaL"
     }
 
     return {
@@ -68,7 +70,7 @@
     }
   }
 
-  function getNode(type, text) {
+  function getNewNode(type, text) {
     const node = document.createElement(type);
     if (text) {
       const textNode = document.createTextNode(text);
@@ -78,42 +80,110 @@
     return node;
   }
 
-  function getH1Node(text) {
-    const node = getNode("h1", text);
-    node.style.fontSize = "3rem";
+  function getNewH1Node(text) {
+    const node = getNewNode("h1", text);
+    node.style.fontSize = "0.75em";
+    node.style.paddingBottom = "0.5em";
     return node;
   }
 
-  function getH2Node(text) {
-    const node = getNode("h2", text);
-    node.style.fontSize = "2rem";
+  function getNewH2Node(text) {
+    const node = getNewNode("h2", text);
+    node.style.fontSize = "0.4em";
     return node;
   }
 
-  function getPNode(text) {
-    const node = getNode("p", text);
-    node.style.fontSize = "1rem";
+  function getNewPNode(text) {
+    const node = getNewNode("p", text);
+    node.style.fontSize = "0.4em";
+    node.style.paddingBottom = "0.8em";
     return node;
   }
 
-  function getImgNode(src) {
-    const node = getNode("img");
-    node.src = src;
-    node.style.maxHeight = "500px";
+  function getNewBoldNode(text) {
+    const node = getNewNode("strong");
+    const textNode = getNewPNode(text);
+    node.appendChild(textNode);
     return node;
   }
 
-  function createTitleNode(title) {
-    const root = getNode("div");
+  function getNewImgNode(src) {
+    const node = getNewNode("div");
+    node.style.height = "500px";
+
+    const imgNode = getNewNode("img");
+    imgNode.src = src;
+    imgNode.style.maxHeight = "500px";
+    imgNode.style.maxWidth = "500px";
+    imgNode.style.margin = "auto";
+    node.appendChild(imgNode);
+
+    return node; 
+  }
+
+  function createTitleNode(name, credits) {
+    const root = getNewNode("div");
     root.style.display = "flex";
     root.style.justifyContent = "space-between";
-    root.style.alignItems = "center";
+    root.style.alignItems = "end";
+    root.style.borderBottom = "1px solid black";
 
-    const titleNode = getH1Node(title.h1);
+    const titleNode = getNewH1Node(name);
     root.appendChild(titleNode);
 
-    const creditsNode = getPNode("Bidara by NASA PeTaL");
+    const creditsNode = getNewPNode(credits);
     root.appendChild(creditsNode);
+
+    return root;
+  }
+
+  function createMessageNode(role, text, files) {
+    const root = getNewNode("div");
+    root.style.display = "flex";
+    root.style.justifyContent = "start";
+    root.style.paddingTop = "0.5em";
+    root.style.paddingBottom = "0.5em";
+    root.style.alignItems = "start";
+    root.style.borderBottom = "1px solid rgb(180,180,180)";
+
+    const roleNode = getNewNode("div");
+    roleNode.style.paddingRight = "1.75em";
+    roleNode.style.paddingTop = "0";
+    roleNode.style.paddingBottom= "0";
+    roleNode.style.marginTop = "0";
+    roleNode.style.marginBottom= "0";
+    roleNode.style.width = "1.75em";
+    roleNode.style.height = "0.6em";
+    roleNode.style.lineHeight = "0.6em";
+    const roleHeading = getNewBoldNode(role);
+    roleNode.appendChild(roleHeading);
+    root.appendChild(roleNode);
+
+    const contentNode = getNewNode("div");
+    contentNode.style.width = "100%";
+    const textNode = getNewPNode(text);
+    contentNode.appendChild(textNode)
+
+    if (files) {
+      files.forEach((file) => {
+        if (file.type === "image") {
+          console.log("adding image node");
+
+          const imgNode = getNewImgNode(file.src);
+          contentNode.appendChild(imgNode);
+
+        } else if (file.name) {
+          const fileNameNode = getNewPNode(`(file) : [${file.name}]`);
+          contentNode.appendChild(fileNameNode);
+
+        } else {
+          const fileNameNode = getNewPNode("(file) : [unnamed file]");
+          contentNode.appendChild(fileNameNode);
+        }
+      })
+    }
+
+    root.appendChild(contentNode);
 
     return root;
   }
@@ -122,46 +192,22 @@
     const title = tree.title;
     const contents = tree.contents;
 
-    const root = getNode("div");
+    const root = getNewNode("div");
     root.style.fontSize = "32px";
 
-    const titleNode = createTitleNode(title);
+    const titleNode = createTitleNode(title.name, title.credits);
     root.appendChild(titleNode);
 
-    const contentsNode = getNode("div");
+    const contentsNode = getNewNode("div");
 
     contents.forEach(content => {
-      const contentNode = getNode("div");
+      const role = content.role;
+      const text = content.text;
+      const files = content.files;
 
-      const roleNode = getH2Node(content.h2);
-      contentNode.appendChild(roleNode);
+      const messageNode = createMessageNode(role, text, files);
 
-      if (content.p) {
-        const textNode = getPNode(content.p);
-        contentNode.appendChild(textNode)
-      } 
-
-      if (content.files) {
-        content.files.forEach((file) => {
-          if (file.type === "image") {
-            const breakNode = getNode("br");
-            contentNode.appendChild(breakNode);
-
-            const imgNode = getImgNode(file.src);
-            contentNode.appendChild(imgNode);
-
-          } else if (file.name) {
-            const fileNameNode = getPNode(`(file) : [${file.name}]`);
-            contentNode.appendChild(fileNameNode);
-
-          } else {
-            const fileNameNode = getPNode("(file) : [unnamed file]");
-            contentNode.appendChild(fileNameNode);
-          }
-        })
-      }
-
-      contentsNode.appendChild(contentNode);
+      contentsNode.appendChild(messageNode);
     })
 
     root.appendChild(contentsNode);
@@ -193,7 +239,6 @@
 
     const messagesHtml = htmlTreeToHtml(messagesTree);
 
-    console.log(messagesHtml);
     htmlToPdf(title, messagesHtml);
   }
 
@@ -205,7 +250,7 @@
 </script>
 
 <button class="w-full h-full p-1 flex justify-between items-center focus:outline-none" on:click={handleExport}>
-	<p>Export to PDF</p>
+  <p>Export to PDF</p>
 </button>
 
 <style>

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -4,6 +4,7 @@
     import MenuItem from './MenuItem.svelte';
     import ThemeSwitcher from './ThemeSwitcher.svelte';
     import ExportMarkdown from './ExportMarkdown.svelte';
+    import ExportPdf from './ExportPdf.svelte';
 	
     export let sidebar = false
     export let chat_name;
@@ -63,6 +64,7 @@
   {/if}
   <Menu>
     <div class="function-container">
+      <MenuItem><ExportPdf bind:chatName={chat_name}/></MenuItem>
       <MenuItem><ExportMarkdown bind:chatName={chat_name}/></MenuItem>
       <MenuItem><ThemeSwitcher/></MenuItem>
     </div>

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -70,7 +70,7 @@
     </div>
     <div class="info-container">
       <MenuItem><a class="w-full h-full p-1" tabindex="0" href="https://forms.gle/xDEixG5UJrFBwDKv5" target="_blank" rel="noopener">Send Feedback</a></MenuItem>
-      <MenuItem><a class="w-full h-full p-1" tabindex="0" href="https://www1.grc.nasa.gov/research-and-engineering/vine/petal/" target="_blank" rel="noopener">Vist PeTaL</a></MenuItem>
+      <MenuItem><a class="w-full h-full p-1" tabindex="0" href="https://www1.grc.nasa.gov/research-and-engineering/vine/petal/" target="_blank" rel="noopener">Visit PeTaL</a></MenuItem>
     </div>
   </Menu>
 </header>


### PR DESCRIPTION
# Export PDF
- add menu button to export chat to PDF
- open to changes in formatting; however, formatting the pdf is a *very* manual process, so it may not be easy or a great use of time to focus on formatting.
- images can be cut off on page breaks. The only alternative I can see to this is inserting a page break before every image, so they appear at the start of the next page and the previous page ends where the image would've been. Open to putting this in instead.
- requires new npm package "jspdf", so `npm install` will be necessary before trying in local

Should merge PR #89 first because this branches off of that.

## Screenshots
<div class="flex">
<img src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/1a6cb182-0bae-4458-8887-aeecb4476484" width="49%"/>
<img src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/0d8e9d35-d90f-4f26-a122-8ca110fea724" width="49%"/>
</div>

## File
[New Chat.pdf](https://github.com/nasa-petal/bidara-deep-chat/files/14962724/New.Chat.pdf)

## Changes
### `ExportPdf.svelte`
- new button component to export chat to pdf
- builds an html representation of the chat, constructs a pdf based on it, and saves the pdf to download
- includes images, but can cut them off on page breaks due to the nature of creating a pdf programmatically
- replaces other files with "(file) :[<insert file name>]"

### `Navbar.svelte
- add export to pdf button into menu in the navbar

### `package.json` and `package-lock.json`
- include new `jspdf` package

### `rollup.config.js`
- Add `inlineDynamicImports: true` attribute to build output because of new `jspdf` package
- needed because `jspdf` doesn't support ES, and this attribute is the only thing I could find to allow that support