### PR TITLE
Keyboard Support for Deep-Chat Inputs

### DIFF
--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -105,6 +105,7 @@
 
   async function onComponentRender() {
     deepChatRef = document.getElementById("chat-element");
+    setDeepChatKeyboardSupport();
     // save key to localStorage.
     // The event occurs before key is set, and again, after key is set.
     if (!key && this._activeService.key) {
@@ -116,6 +117,7 @@
     if (!loadedMessages) {
       await loadMessages(thread)
     }
+
 
     setTimeout(()=> loading = false, 400);
   }
@@ -142,6 +144,22 @@
         currRunId = response.id;
     }
     return response;
+  }
+
+  function setDeepChatKeyboardSupport() {
+    const shadowRoot = deepChatRef.shadowRoot;
+    const input = shadowRoot.getElementById("input");
+    const inputButtons = input.getElementsByClassName("input-button");
+    inputButtons.forEach(button => {
+      const buttonClickEventListener = button.onclick;
+
+      if (!buttonClickEventListener) {
+        return
+      }
+
+      button.tabIndex = 0;
+      button.addEventListener('keydown', (e)=>{ if (e.key === 'Enter') buttonClickEventListener(e); });
+    });
   }
 </script>
 
@@ -319,6 +337,9 @@
     }
     img {
       max-width: 100%;
+    }
+    button:focus-visible {
+      outline: 5px auto -webkit-focus-ring-color; 
     }
     ::-webkit-scrollbar {
       width: 8px;


### PR DESCRIPTION
# Keyboard Support for Deep-Chat Inputs
- add keyboard support for deep-chat inputs: file attachment, voice input

## Changes
### `AssistantDeepChat.svelte`
- add function for setting tabindex and copying the `onclick` event listener to the `keydown` listener checking for "Enter" key
  - should function like any other keyboard supported button on our site
- check if `onclick` event listener exists before setting it. 
  - submit button does not have one at render, and frequently changes it. this makes it difficult to set that similarly, but it's also unnecessary since hitting enter while in the text field works the same.
  
- set `outline` to match other keyboard focusable elements