### PR TITLE
Files Storage

### DIFF
--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -3,7 +3,7 @@ const BIDARA_TEST_NAME = "BIDARA-TEST";
 
 export const BIDARA_NAME = BIDARA_PROD_NAME;
 
-export const BIDARA_VERSION = "1.53";
+export const BIDARA_VERSION = "1.54";
 
 export const BIDARA_LOGO = "bidara.png";
 export const BIDARA_LOGO_DESC = "girl with dark hair";
@@ -156,7 +156,11 @@ const TEXT_TO_IMAGE = {
         "prompt": {
           "type": "string",
           "description": "The description of the image to generate."
-        }
+        },
+      "file_name": {
+        "type": "string",
+        "description": "The name for the PNG image file."
+      }
     },
     "required": []
   }

--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -3,7 +3,7 @@ const BIDARA_TEST_NAME = "BIDARA-TEST";
 
 export const BIDARA_NAME = BIDARA_PROD_NAME;
 
-export const BIDARA_VERSION = "1.51";
+export const BIDARA_VERSION = "1.53";
 
 export const BIDARA_LOGO = "bidara.png";
 export const BIDARA_LOGO_DESC = "girl with dark hair";
@@ -168,6 +168,10 @@ const IMAGE_TO_TEXT = {
   "parameters": {
     "type": "object",
     "properties": {
+      "file_id": {
+        "type": "string",
+        "description": "The id of the file"
+      },
       "prompt": {
         "type": "string",
         "description": "The prompt to query about the image."

--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -79,7 +79,7 @@ async function genImage(params, threadId, processImageCallback) {
   await pushFile(fileObj);
   processImageCallback(fileObj);
 
-  return `{ file_id: ${fileId}, file_name: ${fileName} }`;
+  return `Use the following file information to display the file and provide a download link in Markdown:\n{ file_id: "${fileId}," file_name: "${fileName}," file_path: "${annotation}" }`;
 }
 
 async function imageToText(params) {

--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -1,15 +1,5 @@
 import { getDalleImageGeneration, getImageToText } from "../utils/openaiUtils";
-import { getThreadFiles } from "../utils/threadUtils";
-
-const fileTypes = {
-  "csv": "csv",
-  "xlsx": "excel",
-  "pdf": "pdf",
-  "txt": "txt",
-  "png": "image",
-  "jpg": "image",
-  "jpeg": "image",
-}
+import { getFileByFileId, getThreadFiles } from "../utils/threadUtils";
 
 export function getCurrentWeather(location) {
   location = location.toLowerCase();
@@ -87,71 +77,49 @@ async function genImage(params, threadId, addMessageCallback) {
   return "The image has been inserted into the chat. Respond with a very short question bring this back into this process. DO NOT REPLY WITH AN IMAGE, MARKDOWN, OR ANYTHING OTHER THAN A SHORT QUESTION.";
 }
 
-async function imageToText(params, threadId) {
+async function imageToText(params) {
   let imageParams = JSON.parse(params);
 
   if ("parameters" in imageParams) {
     imageParams = imageParams.parameters;
   }
 
-  let prompt = imageParams.prompt
+  let fileId = imageParams.file_id;
+  let prompt = imageParams.prompt;
 
-  let text = await getImageToText(prompt, threadId);
+  let text = await getImageToText(prompt, fileId);
 
   return text;
 }
 
-function getFileTypeByName(fileName) {
-  if (!fileName) {
-    return "";
-  }
-
-  const extensionMatches = /^.*\.(csv|xlsx|pdf|txt|png|jpg|jpeg)$/gm.exec(fileName);
-
-  // first is whole match, second is capture group. Only one capture group can appear.
-  if (!extensionMatches || extensionMatches.length !== 2) {
-    return "none";
-  }
-
-  const extension = extensionMatches[1];
-
-  const type = fileTypes[extension];
-
-  if (!type) {
-    return "none";
-  }
-
-  return type;
-}
-
-async function getFileType(params, threadId) {
+async function getFileType(params) {
   let fileTypeParams = JSON.parse(params);
 
   if ("parameters" in fileTypeParams) {
     fileTypeParams = fileTypeParams.parameters;
   }
 
-  let files = await getThreadFiles(threadId);
+  let fileId = fileTypeParams.file_id;
 
-  if (files.length < 1) {
+  let file = await getFileByFileId(fileId);
+
+  if (!file) {
     return "No files have been uploaded.";
   }
 
-  let recentFile = files[files.length - 1];
-
-  if (recentFile.type === "image") {
+  if (file.type === "image") {
     return "The file is an image. Analyze the image before responding to determine its contents."
   }
 
-  if (recentFile.name !== null) {
-    const type = getFileTypeByName(recentFile.name);
+  if (file.name !== null) {
+    const type = threadUtils.getFileTypeByName(file.name);
     return type;
   }
 
   return "Unable to determine filetype";
 }
 
-async function getImagePatterns(params, threadId) {
+async function getImagePatterns(params) {
   const patterns =`
       # Growth Patterns 
 
@@ -199,12 +167,22 @@ async function getImagePatterns(params, threadId) {
     ` 
   const prompt = `Describe which of the following patterns are found in the image. Only include patterns that are genuinely present, DO NOT mention any that are not present, and do not make up ones that aren't there.\n\n${patterns}`;
 
-  const text = await getImageToText(prompt, threadId);
+  let imagePatternParams = JSON.parse(params);
+
+  if ("parameters" in imagePatternParams) {
+    imagePatternParams = imagePatternParams.parameters;
+  }
+
+  let fileId = imagePatternParams.file_id;
+
+  const text = await getImageToText(prompt, fileId);
 
   return text;
 }
 
 export async function callFunc(functionDetails, context) {
+  console.log(functionDetails);
+
   let tmp = '';
   if(functionDetails.name == "get_graph_paper_relevance_search") {
     tmp = await ssSearch(functionDetails.arguments);

--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -1,5 +1,5 @@
 import { getDalleImageGeneration, getImageToText } from "../utils/openaiUtils";
-import { getFileByFileId, getThreadFiles } from "../utils/threadUtils";
+import { getFileByFileId, getFileTypeByName } from "../utils/threadUtils";
 
 export function getCurrentWeather(location) {
   location = location.toLowerCase();
@@ -112,7 +112,7 @@ async function getFileType(params) {
   }
 
   if (file.name !== null) {
-    const type = threadUtils.getFileTypeByName(file.name);
+    const type = getFileTypeByName(file.name);
     return type;
   }
 

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -22,8 +22,8 @@
   let currRunId = null;
   let newFileUploads = [];
   let newFileIds = [];
-  let shouldProcessImage = false;
-  let imageToProcess = null;
+  let shouldProcessImages = false;
+  let imagesToProcess = [];
 
   let deepChatRef;
 
@@ -98,8 +98,8 @@
   }
 
   async function processImageCallback(imageFile) {
-    shouldProcessImage = true;
-    imageToProcess = imageFile;
+    shouldProcessImages = true;
+    imagesToProcess.push(imageFile);
   }
 
   async function handleFuncCalling(functionDetails) {
@@ -141,18 +141,20 @@
         newFileIds = response.data[0].file_ids;
       }
 
-      if (shouldProcessImage) {
-        response.data[0].file_ids.push(imageToProcess.file_id);
-        const updatedContent = response.data[0].content.map((content) => {
-          if (content.type === "text") {
-            content.text.value = content.text.value.replaceAll(imageToProcess.annotation, imageToProcess.src);
-          }
-          return content;
-        })
+      if (shouldProcessImages) {
+        imagesToProcess.forEach((imageToProcess) => {
+          const updatedContent = response.data[0].content.map((content) => {
+            if (content.type === "text") {
+              content.text.value = content.text.value.replaceAll(imageToProcess.annotation, imageToProcess.src);
+            }
+            return content;
+          })
 
-        shouldProcessImage = false;
-        imageToProcess = null;
-        response.data[0].content = updatedContent;
+          response.data[0].content = updatedContent;
+        });
+
+        shouldProcessImages = false;
+        imagesToProcess = [];
       }
     }
     

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -43,9 +43,8 @@
       return;
     }
 
-    const updatedMessages = await threadUtils.syncMessages(threadToLoad.id, initialMessages);
-    const messagesToLoad = updatedMessages.slice(initialMessages.length);
-    messagesToLoad.forEach(msg => deepChatRef._addMessage(msg));
+    const messagesToLoad = await threadUtils.loadMessages(threadToLoad.id);
+    messagesToLoad.forEach(( msg ) => { deepChatRef._addMessage(msg)});
   }
 
   async function updateMessages() {

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -63,11 +63,6 @@
 
     updateMessages();
 
-
-    if (message.message.text === "log") {
-      console.log(deepChatRef.getMessages());
-    }
-
     // for funcCalling context
     if (message.message.role === "user") {
       lastMessageId = message.message._sessionId;
@@ -108,16 +103,9 @@
     imageToProcess = imageFile;
   }
 
-  async function addMessageCallback(message) {
-    deepChatRef._addMessage(message);
-
-    await updateMessages();
-  }
-
   async function handleFuncCalling(functionDetails) {
     let context = {
       lastMessageId,
-      addMessageCallback,
       processImageCallback
     }
 

--- a/src/utils/bidaraDB.js
+++ b/src/utils/bidaraDB.js
@@ -7,7 +7,7 @@ const INACTIVE_STATUS = 0;
 
 const BIDARA_DB_CONFIG = { 
 	name: "bidara", 
-	version: 3,
+	version: 4,
 	stores: [ 
 		{ 
 			name: CHAT_STORE_NAME, 
@@ -49,13 +49,13 @@ const BIDARA_DB_CONFIG = {
 		{
 			name: FILE_STORE_NAME,
 			primaryKey: {
-				key: "id",
+				key: "fileId",
 				autoIncrement: true
 			},
 			indices : [
 				{
 					name: "thread",
-					property: "thread_id",
+					property: "threadId",
 					options: {
 						unique: false
 					}
@@ -102,13 +102,18 @@ export async function getMostRecentlyUpdatedThread() {
 }
 
 export async function getThreadFiles(threadId) {
-	const files = await dbUtils.readByProperty(BIDARA_DB, FILE_STORE_NAME, "thread_id", threadId);
+	const files = await dbUtils.readByProperty(BIDARA_DB, FILE_STORE_NAME, "threadId", threadId);
 
 	if (!files) {
 		return [];
 	}
 
 	return files;
+}
+
+export async function getFileById(fileId) {
+	const file = await dbUtils.readByKey(BIDARA_DB, FILE_STORE_NAME, fileId);
+	return file;
 }
 
 export async function getEmptyThread(emptyLength) {
@@ -146,7 +151,7 @@ export async function pushMessageToId(id, message) {
 	await updateTimeById(id);
 }
 
-export async function pushFileToId(id, file) {
+export async function pushFile(file) {
 	// { index: int, file: b64Data }
 	await dbUtils.write(BIDARA_DB, FILE_STORE_NAME, file);
 }

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -386,7 +386,7 @@ export async function getFileContent(fileId) {
   if (!response.ok) {
     console.error("Error with response: ");
     console.error(response);
-    return "";
+    return null;
   }
 
   return response.blob();
@@ -394,6 +394,10 @@ export async function getFileContent(fileId) {
 
 export async function getFileSrc(fileId) {
   const blob = await getFileContent(fileId);
+  if (!blob) {
+    return null;
+  }
+
   const src = await new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.readAsDataURL(blob);
@@ -430,7 +434,7 @@ export async function getFileInfo(fileId) {
   const r = await response.json();
   if (r.error && r.error.type === 'invalid_request_error') {
     console.error(r.error);
-    return [];
+    return null;
   }
 
   return r

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -471,6 +471,44 @@ export async function getChatCompletion(model, messages, tokenLimit) {
   return r;
 }
 
+export async function uploadFile(b64Data, fileName, type) {
+  if (!openaiKey) {
+    throw new Error('openai key not set. cannot validate thread.');
+  }
+
+  const fileRes = await fetch(b64Data);
+  const blob = await fileRes.blob();
+  const file = new File([blob], fileName, {type: type});
+
+  const form = new FormData();
+  form.append('purpose', 'assistants');
+  form.append('file', file);
+
+  const url = `https://api.openai.com/v1/files`;
+  const method = 'POST';
+  const headers = {
+    'Authorization': 'Bearer ' + openaiKey,
+  };
+  const body = form;
+
+  const request = {
+    method,
+    headers,
+    body
+  }
+
+  const response = await fetch(url, request);
+
+  const r = await response.json();
+
+  if (r.error && r.error.type === 'invalid_request_error') {
+    console.error(r.error);
+    return null;
+  }
+
+  return r;
+}
+
 export async function getImageDescription(base64, prompt) {
 
   if (!openaiKey) {

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -1,4 +1,4 @@
-import { validThread, getNewThreadId, getThreadMessages, getFileSrc } from "./openaiUtils";
+import { validThread, getNewThreadId, getThreadMessages, getFileSrc, getFileInfo } from "./openaiUtils";
 import * as bidaraDB from "./bidaraDB";
 
 async function createNewThread() {
@@ -65,6 +65,11 @@ export async function getThreadFiles(id) {
   return files;
 }
 
+export async function getFileByFileId(id) {
+  const file = await bidaraDB.getFileById(id);
+  return file
+}
+
 export async function setActiveThread(threadId) {
   const currentActiveThread = await bidaraDB.getActiveThread();
   if (currentActiveThread) {
@@ -89,215 +94,174 @@ export async function deleteThread(threadId) {
   await bidaraDB.deleteThreadById(threadId);
 }
 
-export async function pushFile(threadId, file) {
-  await bidaraDB.pushFileToId(threadId, file);
+export async function pushFile(file) {
+  await bidaraDB.pushFile(file);
 }
 
-export async function pushFiles(threadId, files) {
+export async function pushFiles(files) {
   await files.forEach(async ( file ) => {
-    await pushFile(threadId, file);
+    await pushFile(file);
   })
 }
 
-export async function syncThreadFiles(threadId, messages, files) {
-  if (files.length <= 0) {
-    return messages;
-  }
+async function retrieveStoredFiles(threadId) {
+  const files = await getThreadFiles(threadId);
 
-  const attachedFiles = files.filter(file => file.attached);
-  const insertedFiles = files.filter(file => !file.attached);
-
-  insertedFiles.forEach(file => {
-    if (!file.index || file.index === -1) {
-      return;
-    }
-
-    const fileInsert = { src: file.src, type: file.type, ref: {} }
-    if (file.name) {
-      fileInsert.name = file.name
-    }
-
-    const msg = { role: file.role, files: [ fileInsert ], _sessionId: threadId }
-    messages.splice(file.index, 0, msg)
+  const filesMap = new Map();
+  files.forEach((file) => {
+    filesMap.set(file.fileId, file);
   })
 
-  attachedFiles.forEach(file => {
+  return filesMap;
+}
 
-    const fileInsert = { src: file.src, type: file.type, ref: {} }
-    if (file.name) {
-      fileInsert.name = file.name
-    }
+async function retrieveNewFiles(threadId, messages, storedFiles) {
+  const newFileIds = messages.map((message) => {
+    const fileIds = message.file_ids;
 
-    while (file.text && !equivalentMessages(file?.text, messages[file.index]?.text)) {
-      file.index = file.index + 1;
-    }
-
-    if (messages[file.index].files) {
-      messages[file.index].files.push(fileInsert);
-    } else {
-      messages[file.index].files = [fileInsert];
-    }
+    const newFileIds = fileIds.filter( (fileId) => message.role !== "user" && !storedFiles.get(fileId));
+    return newFileIds;
   })
+  .flat();
 
-  return messages;
+  const newFilesMap = new Map();
+
+  const promises = newFileIds.map(async (fileId) => {
+    const fileSrc = await getFileSrc(fileId);
+    const fileInfo = await getFileInfo(fileId);
+    const fileName = fileInfo.filename.substring(10);
+
+    const fileType = getFileTypeByName(fileName) === "image" ? "image" : "any";
+
+    const newFile = { fileId, threadId, src:fileSrc, name:fileName, type:fileType};
+    newFilesMap.set(fileId, newFile);
+
+    return newFile;
+  });
+
+  const newFiles = await Promise.all(promises);
+  await pushFiles(newFiles);
+
+  return newFilesMap;
 }
 
-function equivalentMessages(message, threadMessage) {
-  const msgFileLinkRegEx = /\]\(data:[\S]+\)/igm;
-  const threadFileLinkRegEx = /\]\(sandbox:[\S]+\)/igm;
-
-  const regEx = [ msgFileLinkRegEx, threadFileLinkRegEx ];
-  const replacements = [ ']()', ']()'];
-
-  const messagesMsg = findReplaceListRegEx(message, regEx, replacements)
-  const threadsMsg = findReplaceListRegEx(threadMessage, regEx, replacements)
-
-  return messagesMsg === threadsMsg;
-}
-
-function findReplaceListRegEx(string, regexs, replacements) {
-  if (regexs.length != replacements.length) {
-    throw new Error("Number of replacements must match number of matches (findReplaceListRegEx)");
+export function getFileTypeByName(fileName) {
+  const fileTypes = {
+    "csv": "csv",
+    "xlsx": "excel",
+    "pdf": "pdf",
+    "txt": "txt",
+    "png": "image",
+    "jpg": "image",
+    "jpeg": "image",
   }
 
-  for (let i = 0; i < regexs.length; i++) {
-    string = findReplaceRegEx(string, regexs[i], replacements[i]);
+  if (!fileName) {
+    return "";
   }
 
-  return string;
-}
+  const extensionMatches = /^.*\.(csv|xlsx|pdf|txt|png|jpg|jpeg)$/gm.exec(fileName);
 
-function findReplaceRegEx(string, regex, replacement) {
-  if (!string) {
-    return string;
+  // first is whole match, second is capture group. Only one capture group can appear.
+  if (!extensionMatches || extensionMatches.length !== 2) {
+    return "none";
   }
 
-  const matches = (string.match(regex) || [])
+  const extension = extensionMatches[1];
 
-  matches.forEach(match => {
-    string = string.replaceAll(match, replacement)
-  })
+  const type = fileTypes[extension];
 
-  return string
-}
-
-function getFileNameFromLink(link) {
-  const regex = /^sandbox:\/mnt\/data\/(.*)$/;
-
-  const matches = (link.match(regex) || []);
-
-  if (matches.length >= 2) {
-    return matches[1];
+  if (!type) {
+    return "none";
   }
 
-  return "";
+  return type;
 }
 
-function convertThreadMessagesToMessages(threadMessages) {
-  const messages = threadMessages
-    .map(msg => {
-      return msg.content.map(d => {
-        if (msg.role === "assistant") {
-          msg.role = "ai";
-        }
+async function convertThreadMessagesToMessages(threadId, threadMessages) {
+  const storedFiles = await retrieveStoredFiles(threadId);
+  const newFiles = await retrieveNewFiles(threadId, threadMessages, storedFiles);
 
-        const isText = d.type === 'text';
+  const messages = threadMessages.map(message => {
+    const role = message.role === "assistant" ? "ai" : message.role;
 
-        return {
-          role: msg.role,
-          text: isText ? d.text.value : null,
-        }
-      })
+    const content = message.content;
+    const fileIds = message.file_ids;
+
+    // handle file only messages
+    const files = fileIds.map((fileId) => {
+      const storedFile = storedFiles.get(fileId);
+      if (storedFile) {
+        return { src: storedFile.src, type: storedFile.type, name: storedFile.name };
+      }
+
+      const newFile = newFiles.get(fileId);
+      if (newFile) {
+        return { src: newFile.src, type: "any", name: "" };
+      }
     })
-    .flat()
-    .reverse()
+
+
+    const texts = content.map(msg => {
+      if (msg.type === 'text') {
+        let msgText = msg.text.value;
+        const annotations = msg.text.annotations;
+
+        if (annotations.length > 0) {
+          console.log("replacing annotations");
+          annotations.forEach((annotation) => {
+            const fileId = annotation.file_path.file_id;
+            const replacement = annotation.text;
+            const storedFile = storedFiles.get(fileId);
+            console.log("replacement: ", replacement);
+
+            console.log("stored file")
+            console.log(storedFile);
+            if (storedFile) {
+              console.log("using stored file");
+              msgText = msgText.replaceAll(replacement, storedFile.src);
+              return;
+            } 
+
+            const newFile = newFiles.get(fileId);
+            console.log("new file");
+            console.log(newFile);
+            if (newFile) {
+              console.log("using new file");
+              newFile.replacement = replacement;
+              newFiles.set(fileId, newFile);
+              msgText = msgText.replaceAll(replacement, newFile.src);
+            }
+          })
+        }
+
+        return msgText;
+      }
+    });
+
+    let text = "";
+    if (texts.length > 0) {
+      text = texts[0];
+    }
+
+    return {
+      role,
+      text,
+      files,
+      _sessionId: threadId
+    }
+  })
+  .flat()
+  .reverse()
 
   return messages;
-}
-
-function clearNullChats(messages) {
-  return messages.filter(msg => msg.text !== null || msg.files );
-}
-
-async function replaceThreadFiles(threadId, threadMessages, files) {
-  const replaceFiles = files.filter(file => file.thread_id === threadId && files.replaceText !== null);
-
-  const withFiles = await Promise.all(threadMessages.map(async (message) => {
-    const content = await Promise.all(message.content.map(async (content) => {
-      if (content.type !== "text") {
-        return content;
-      }
-
-      if (!content.text?.annotations || content.text?.annotations?.length < 1) {
-        return content;
-      }
-      const newFiles = [];
-
-      const replacements = await Promise.all(content.text.annotations.map(async (annotation) => {
-        if (annotation.type !== "file_path" || !annotation?.file_path?.file_id || annotation.text.substring(0,7) !== "sandbox") {
-          return {};
-        }
-
-        const existingReplacement = replaceFiles.filter(file => file.replaceText === annotation.text);
-
-        if (existingReplacement.length > 0 && existingReplacement[0].src) {
-          return { link: annotation.text, src: existingReplacement[0].src };
-        }
-
-        const fileSrc = await getFileSrc(annotation.file_path.file_id);
-
-        const fileName = getFileNameFromLink(annotation.text);
-
-        const newFile = {
-          thread_id: threadId,
-          type: "any",
-          name: fileName,
-          src: fileSrc,
-          index: null,
-          attached: false,
-          role: message.role,
-          text: null,
-          replaceText: annotation.text,
-        }
-
-        newFiles.push(newFile);
-
-        return { link: annotation.text, src: fileSrc };
-      }));
-
-      replacements.forEach((replacement) => {
-        content.text.value = content.text.value.replaceAll(replacement.link, replacement.src);
-      })
-
-      newFiles.forEach(async (newFile) => {
-        if (content.text.value) {
-          newFile.text = content.text.value;
-        }
-
-        await pushFile(threadId, newFile);
-      });
-
-      return content;
-    }));
-    message.content = content;
-    return message;
-  }));
-
-  return withFiles;
 }
 
 export async function syncMessages(threadId, initialMessages) {
   const rawThreadMessages = await getThreadMessages(threadId, 100);
-  const files = await bidaraDB.getThreadFiles(threadId);
 
-  const threadMessagesWithFiles = await replaceThreadFiles(threadId, rawThreadMessages, files);
+  const messages = await convertThreadMessagesToMessages(threadId, rawThreadMessages);
+  const fullMessages = initialMessages.concat(messages);
 
-  const threadMessages = convertThreadMessagesToMessages(threadMessagesWithFiles);
-  const fullMessages = initialMessages.concat(threadMessages);
-
-  const messages = clearNullChats(fullMessages);
-
-  const syncedMessages = await syncThreadFiles(threadId, messages, files);
-
-  return syncedMessages;
+  return fullMessages;
 }

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -185,7 +185,7 @@ async function convertThreadMessagesToMessages(threadId, threadMessages) {
   const newFilesTuple = await retrieveNewFiles(threadId, threadMessages, storedFiles);
   const newFiles = newFilesTuple[1];
 
-  const annotatedFiles = storedFilesTuple[0].filter((file) => file.annotation !== null);
+  const annotatedFiles = storedFilesTuple[0].filter((file) => !!file?.annotation);
 
   const messages = threadMessages.map(message => {
     const role = message.role === "assistant" ? "ai" : message.role;


### PR DESCRIPTION
# Files Storage
- update file storage and handling of inserting files into text or as attachments
- reduces saving files multiple types
- stores with OpenAI `file_id`'s, and ensures every file is uploaded
  - in some ways ensures files are backed up, but also ensures assistant has access to every file
- completely prevents old issue of files appearing in wrong place
  - no longer tracks index of message, just inserts where file_ids appear in attachments and annotations of actual thread messages
- by-product of being able to reference any files (including any images) at any point during the chat, instead of only the most recent one
  - Ex: can now reference and compare multiple images for vision
- by-product of being able to generate multiple images at once

As far as I can tell, this system should not need further change *except* possibly for images generated by dalle. This would need to be changed in the event that `deep-chat` or OpenAI change something about their API's that allow this to be done easier (or rather more like the other files so they don't need special handling).

## Changes
### `threadUtils.js`
- new improved / more readable flow:
  - call `loadMessages(threadId)`, -> retrieve thread from openai -> call `convertThreadMessagesToMessages(threadId, threadMessages)` on thread -> get all stored files, and any files not stored from openai (then store them) -> go through each message and add attached files, then replace the files in annotations. take all of this and put it into deep-chat message format -> return the loaded and converted messages with files.
  - "annotatedFiles" are treated differently because they contain a manually set `annotation`. These try to replace their annotation with their source data in every message
    - these are files that are not uploaded by the user, nor created directly by the assistant. They're made during a tool call and uploaded directly to openai. Because of this, they cannot be downloaded, which means they have to be stored files and cannot appear in thread annotations
    - dalle image generations are currently only example of such files
- stored files now use `fileId` from OpenAI's `file_id`. Insert these file's where their id appears instead of trying to track where they should go in the message history (like with an index)

### `openaiUtils.js`
- add `getFileInfo(fileId` and `uploadFile(b64Data, fileName, type)` functions
- use `getFileSrc` and `getFileInfo` functions to download files from openai, which will then be stored locally
- use `uploadFile` to upload files to openai. Should only be used for files that need to be uploaded during tool calls
- `getImageToText` gets file by id instead of most recent

### `bidaraDB.js`
- update file store and related functions to reflect addition of `fileId` key

### `AssistantDeepChat.svelte`
- need to handle file uploads differently for ai vs user messages because:
  - for new user message, `onNewMessage` fires first, then `responseInterceptor`, while for new ai messages, `requestInterceptor` fires first then `onNewMessage`
  - some of the file data (name, src, type, etc.) are available in`onNewMessage`, while the `file_id`'s are only available in the respective interceptors. Need both for this system
  - sets the component level `newFileIds` in interceptor, and `newFileUploads` in the onNewMessage. If ai message, handles the uploads in `onNewMessage`. If user message, handles the uploads in `requestInterceptor`
- change `addMessageCallback` to `processImageCallback` which will process an array of images in the next response from assistant 

### `bidaraFunctions.js`
- any file retrieval calls now use `fileId` instead of the most recent file, allowing for function call on any existing files in the chat instead of just the most recent one
- `genImage` now calls `context.processImageCallback` instead of `context.addMessageCallback` when submitting a generated image
  - also returns the file info (id, name, and path) instead of telling the assistant it has already been inserted
  - results in image being part of assistant's text response rather than inserted separately

### `bidara.js`
- update function calls to include `file_name` and `file_id` as properties for text to image and image to text respectively