### PR TITLE
Assistant ID Storage

### DIFF
--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -4,7 +4,6 @@
   import * as threadUtils from '../utils/threadUtils';
 
   export let key = null;
-  export let asstId = null;
   export let asstConfig = null;
   export let thread = null;
   export let initialMessages = null;
@@ -19,6 +18,7 @@
 
   let lastMessageId;
   let threadId = thread?.id; 
+  let asstId = thread?.asst_id;
   let currRunId = null;
   let newFileUploads = [];
   let newFileIds = [];
@@ -92,7 +92,6 @@
     if (!loadedMessages) {
       await loadMessages(thread)
     }
-
 
     setTimeout(()=> loading = false, 400);
   }

--- a/src/utils/bidaraDB.js
+++ b/src/utils/bidaraDB.js
@@ -172,6 +172,10 @@ export async function setLengthById(id, length) {
 	await dbUtils.updateProperty(BIDARA_DB, CHAT_STORE_NAME, id, "length", length);
 }
 
+export async function setAsstIdById(id, asstId) {
+	await dbUtils.updateProperty(BIDARA_DB, CHAT_STORE_NAME, id, "asst_id", asstId);
+}
+
 export async function setActiveStatusById(id, status) {
 	if (status) {
 		await dbUtils.updateProperty(BIDARA_DB, CHAT_STORE_NAME, id, "active", ACTIVE_STATUS);

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -1,12 +1,13 @@
 import { validThread, getNewThreadId, getThreadMessages, getFileSrc, getFileInfo } from "./openaiUtils";
 import * as bidaraDB from "./bidaraDB";
 
-async function createNewThread() {
+async function createNewThread(asstId) {
   const new_id = await getNewThreadId();
 
   if (new_id) {
     const new_name = "New Chat";
-    return {name: new_name, id: new_id, length: 0, active: true};
+
+    return {name: new_name, id: new_id, asst_id: asstId, length: 0, active: true};
   }
 
   return null;
@@ -28,8 +29,8 @@ export async function getActiveThread() {
   return thread;
 }
 
-export async function getNewThread() {
-  const thread = await createNewThread();
+export async function getNewThread(asstId) {
+  const thread = await createNewThread(asstId);
   await bidaraDB.setThread(thread);
 
   return thread;
@@ -88,6 +89,16 @@ export async function updateThread(thread) {
 
 export async function setThreadLength(id, length) {
   await bidaraDB.setLengthById(id, length);
+}
+
+export async function setThreadAsstId(thread, asstId) {
+  if (!thread.hasOwnProperty("asst_id")) {
+    thread.asst_id = asstId;
+    await bidaraDB.setThread(thread);
+
+  } else {
+    await bidaraDB.setAsstIdById(thread.id, asstId);
+  }
 }
 
 export async function deleteThread(threadId) {


### PR DESCRIPTION
# Assistant ID Storage
- stores assistant id for future retrieval in indexedDB
- allows different threads to have different assistants mapped to them (like for requirements assistant)

