### PR TITLE
remove image download links

### DIFF
--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -5,7 +5,7 @@ const TEST_NAME = "BIDARA-TEST";
 
 export const NAME = PROD_NAME;
 
-export const VERSION = "1.54";
+export const VERSION = "1.55";
 
 export const LOGO = "bidara.png";
 export const LOGO_DESC = "girl with dark hair";

--- a/src/assistant/commonFunctions.js
+++ b/src/assistant/commonFunctions.js
@@ -59,7 +59,7 @@ export async function genImage(params, context) {
   await pushFile(fileObj);
   processImageCallback(fileObj);
 
-  return `Use the following file information to display the file and provide a download link in Markdown:\n{ file_id: "${fileId}," file_name: "${fileName}," file_path: "${annotation}" }`;
+  return `Use the following file information to display the file:\n{ file_id: "${fileId}," file_name: "${fileName}," file_path: "${annotation}" }\nLet them know they can right-click or tap and hold the image to share or save it to a PNG file. Do not provide a download link or mention one.`;
 }
 
 export async function imageToText(params, context) {


### PR DESCRIPTION
remove image download links as they don't work in chrome due to security policy. let user know they can right-click an image to save it. fixes #113 