### PR TITLE
fix bash vs. sh script syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "svelte-touch-to-mouse": "^1.0.0"
   },
   "scripts": {
-    "build": "[[ -z \"${SS_KEY}\" ]] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; rollup -c --bundleConfigAsCjs",
-    "dev": "[[ -z \"${SS_KEY}\" ]] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; rollup -c -w --bundleConfigAsCjs",
+    "build": "[ -z \"${SS_KEY}\" ] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; rollup -c --bundleConfigAsCjs",
+    "dev": "[ -z \"${SS_KEY}\"  ] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; rollup -c -w --bundleConfigAsCjs",
     "start": "sirv public"
   },
   "keywords": [],


### PR DESCRIPTION
- bash accepts "[[" syntax for conditionals, sh doesn't recognize
- "[" is conditional for sh