### PR TITLE
SS Verify results / Filter

### DIFF
--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -1,9 +1,26 @@
 import { ssSearch, genImage, imageToText, getFileType, getImagePatterns } from "./commonFunctions";
 
+export async function bioSsSearch(params, context) {
+
+  const papers = await ssSearch(params, context);
+
+  const resMsg = `Verify the following results to be relevant to the question asked, and related to Biology.
+    If the results do not match these criteria, or if better results could be achieved through updated terms,
+    an additional search should be performed with updated terms.
+
+    <results> 
+    ${papers}
+    </results>
+
+    The results MUST be related to the question AND Biological in nature. Otherwise, you MUST search again without asking for confirmation.
+    `
+
+  return resMsg;
+}
 export async function callFunc(functionDetails, context) {
   let tmp = '';
   if(functionDetails.name == "get_graph_paper_relevance_search") {
-    tmp = await ssSearch(functionDetails.arguments);
+    tmp = await bioSsSearch(functionDetails.arguments);
   }
   else if(functionDetails.name == "text_to_image") {
     if (context?.processImageCallback && context?.lastMessageId) {

--- a/src/assistant/bidaraFunctions.js
+++ b/src/assistant/bidaraFunctions.js
@@ -2,7 +2,16 @@ import { ssSearch, genImage, imageToText, getFileType, getImagePatterns } from "
 
 export async function bioSsSearch(params, context) {
 
-  const papers = await ssSearch(params, context);
+  const updatedParams = JSON.parse(params);
+
+  if (updatedParams.fieldsOfStudy) {
+    updatedParams.fieldsOfStudy += ",Biology";
+  } else {
+    updatedParams.fieldsOfStudy = "Biology";
+  }
+  const stringUpdateParams = JSON.stringify(updatedParams);
+
+  const papers = await ssSearch(stringUpdateParams, context);
 
   const resMsg = `Verify the following results to be relevant to the question asked, and related to Biology.
     If the results do not match these criteria, or if better results could be achieved through updated terms,

--- a/src/assistant/commonFunctions.js
+++ b/src/assistant/commonFunctions.js
@@ -49,7 +49,7 @@ export async function ssSearch(params, context) {
         ${papers}
       </results>
 
-      The results MUST be related to the question AND Biological in nature. Otherwise, an additional search must be performed.
+      The results MUST be related to the question AND Biological in nature. Otherwise, you MUST search again without asking for confirmation.
     `
 
     return resMsg;

--- a/src/assistant/commonFunctions.js
+++ b/src/assistant/commonFunctions.js
@@ -13,6 +13,7 @@ export async function ssSearch(params, context) {
   if ("parameters" in searchParams) {
     searchParams = searchParams.parameters;
   }
+
   let fields = [];
   if (typeof searchParams.fields === 'string' || searchParams.fields instanceof String) {
     fields = searchParams.fields.split(",");
@@ -35,8 +36,24 @@ export async function ssSearch(params, context) {
     if (response.status === 429 || response.code === 429 || response.statusCode === 429) {
       return "Semantic Scholar is currently having issues with their servers. So, for now, searching for academic papers will not work."
     }
-    const papers = await response.json();
-    return JSON.stringify(papers);
+
+    const papersJson = await response.json();
+    const papers = JSON.stringify(papersJson);
+
+
+    const resMsg = `Verify the following results to be relevant to the question asked, and related to Biology.
+      If the results do not match these criteria, or if better results could be achieved through updated terms,
+      an additional search should be performed with updated terms.
+      
+      <results> 
+        ${papers}
+      </results>
+
+      The results MUST be related to the question AND Biological in nature. Otherwise, an additional search must be performed.
+    `
+
+    return resMsg;
+
   } catch (e) {
     console.error('error: ' + e);
     return "Semantic Scholar is currently having issues with their servers. So, for now, searching for academic papers will not work."

--- a/src/assistant/commonFunctions.js
+++ b/src/assistant/commonFunctions.js
@@ -40,19 +40,7 @@ export async function ssSearch(params, context) {
     const papersJson = await response.json();
     const papers = JSON.stringify(papersJson);
 
-
-    const resMsg = `Verify the following results to be relevant to the question asked, and related to Biology.
-      If the results do not match these criteria, or if better results could be achieved through updated terms,
-      an additional search should be performed with updated terms.
-      
-      <results> 
-        ${papers}
-      </results>
-
-      The results MUST be related to the question AND Biological in nature. Otherwise, you MUST search again without asking for confirmation.
-    `
-
-    return resMsg;
+    return papers;
 
   } catch (e) {
     console.error('error: ' + e);


### PR DESCRIPTION
# SS Verify Results
- Instruct assistant to verify SS results are both biological and related to the question asked
- If results are not biological, or related to the question, the assistant will refine the search terms to try for better results
- Assistant may refine and search multiple times, but if results do not show any promise, it will resolve to tell the user a better topic may be necessary
- Filter on "Biology" `fieldsOfStudy` param in request to SS


## Example
<img width="1363" alt="SSVerify" src="https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/33b63b88-7233-47c7-93c2-97e436d7daf0">

## Example conversation with filter
[ChatWithBioFilter.pdf](https://github.com/user-attachments/files/15741219/ChatWithBioFilter.pdf)

*Note: chat demonstrates Bidara finding seal whiskers based on the question mentioned in issue #117*
"How might we suppress vortex-induced vibration and reduce drag in high-sensitivity flow sensors and aero-propulsion flow structures?"