### PR TITLE
Upgrade Assistants V2 and Deep-chat Version (dev)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bidara-deep-chat-svelte",
       "version": "1.0.0",
       "dependencies": {
-        "deep-chat": "^1.4.11",
+        "deep-chat-dev": "^9.0.174",
         "jspdf": "^2.5.1",
         "sirv-cli": "^2.0.0",
         "svelte-agnostic-draggable": "^0.2.0",
@@ -1095,10 +1095,10 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "node_modules/deep-chat": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/deep-chat/-/deep-chat-1.4.11.tgz",
-      "integrity": "sha512-+I79+ZOMXpg3xAGKoaVFkuxF0+HJZmXLBz1hONTIIrALR08r7tnbw0g3rhS9T7dUeMzA84BbxV8HMco9pNQWjw==",
+    "node_modules/deep-chat-dev": {
+      "version": "9.0.174",
+      "resolved": "https://registry.npmjs.org/deep-chat-dev/-/deep-chat-dev-9.0.174.tgz",
+      "integrity": "sha512-OimhAvT8RUEjXqQi5xRWsN2dHvDJC1ZhszWWpvR9MTxiznofKRQlbuWLdfuCcJx5lxJYw8WrPIoS18GJWYnGPQ==",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "remarkable": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bidara-deep-chat-svelte",
       "version": "1.0.0",
       "dependencies": {
-        "deep-chat-dev": "^9.0.174",
+        "deep-chat-dev": "^9.0.179",
         "jspdf": "^2.5.1",
         "sirv-cli": "^2.0.0",
         "svelte-agnostic-draggable": "^0.2.0",
@@ -1096,9 +1096,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/deep-chat-dev": {
-      "version": "9.0.174",
-      "resolved": "https://registry.npmjs.org/deep-chat-dev/-/deep-chat-dev-9.0.174.tgz",
-      "integrity": "sha512-OimhAvT8RUEjXqQi5xRWsN2dHvDJC1ZhszWWpvR9MTxiznofKRQlbuWLdfuCcJx5lxJYw8WrPIoS18GJWYnGPQ==",
+      "version": "9.0.179",
+      "resolved": "https://registry.npmjs.org/deep-chat-dev/-/deep-chat-dev-9.0.179.tgz",
+      "integrity": "sha512-IlQJloUFgpdi4zGa0ah8wv/9nalfPu9gV/4azrkSqtDwo4blwrOs+EfMtHpCFkjRGz77ZTuJXbg2S9xCBjwZxg==",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "remarkable": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "svelte": "^4.2.17"
   },
   "dependencies": {
-    "deep-chat-dev": "^9.0.174",
+    "deep-chat-dev": "^9.0.179",
     "jspdf": "^2.5.1",
     "sirv-cli": "^2.0.0",
     "svelte-agnostic-draggable": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "svelte": "^4.2.17"
   },
   "dependencies": {
-    "deep-chat": "^1.4.11",
+    "deep-chat-dev": "^9.0.174",
     "jspdf": "^2.5.1",
     "sirv-cli": "^2.0.0",
     "svelte-agnostic-draggable": "^0.2.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -53,7 +53,7 @@
     } 
 
     // If an empty thead is already created, prevents creating a new one
-    const emptyThread = await threadUtils.getEmptyThread(activeAsst.initialMessages.length);
+    const emptyThread = await threadUtils.getEmptyThread(activeAsst.history.length);
     if (emptyThread) {
       await switchActiveThread(emptyThread);
 

--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -5,7 +5,7 @@ const TEST_NAME = "BIDARA-TEST";
 
 export const NAME = PROD_NAME;
 
-export const VERSION = "1.60";
+export const VERSION = "1.70";
 
 export const LOGO = "bidara.png";
 export const LOGO_DESC = "girl with dark hair";

--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -3,9 +3,9 @@ import { PAPER_SEARCH_FUNC, TEXT_TO_IMAGE, IMAGE_TO_TEXT, GET_FILE_TYPE, GET_IMA
 const PROD_NAME = "BIDARA";
 const TEST_NAME = "BIDARA-TEST";
 
-export const NAME = TEST_NAME;
+export const NAME = PROD_NAME;
 
-export const VERSION = "1.61";
+export const VERSION = "1.60";
 
 export const LOGO = "bidara.png";
 export const LOGO_DESC = "girl with dark hair";
@@ -92,7 +92,7 @@ Nature uses shape to determine functionality.
 
 export const FUNCTIONS = [
   { type: "code_interpreter" },
-  { type: "retrieval" },
+  { type: "file_search" },
   { type: "function", function: PAPER_SEARCH_FUNC },
   { type: "function", function: TEXT_TO_IMAGE },
   { type: "function", function: IMAGE_TO_TEXT },

--- a/src/assistant/bidara.js
+++ b/src/assistant/bidara.js
@@ -3,9 +3,9 @@ import { PAPER_SEARCH_FUNC, TEXT_TO_IMAGE, IMAGE_TO_TEXT, GET_FILE_TYPE, GET_IMA
 const PROD_NAME = "BIDARA";
 const TEST_NAME = "BIDARA-TEST";
 
-export const NAME = PROD_NAME;
+export const NAME = TEST_NAME;
 
-export const VERSION = "1.55";
+export const VERSION = "1.61";
 
 export const LOGO = "bidara.png";
 export const LOGO_DESC = "girl with dark hair";
@@ -100,7 +100,7 @@ export const FUNCTIONS = [
   { type: "function", function: GET_IMAGE_PATTERNS },
 ]
 
-export const INITIAL_MESSAGES = [
+export const HISTORY = [
   { role: "ai", text: `Hi, I'm **${NAME}**, ${TAGLINE}. ${DESCRIPTION}` },
   { role: "ai", text: `Before we begin, please be advised:\n\n‣ ${ADVISORY}` },
   { role: "ai", text: `${GREETING}` }

--- a/src/assistant/index.js
+++ b/src/assistant/index.js
@@ -4,7 +4,7 @@ import { funcCalling as bidaraFuncCalling } from './bidaraFunctions'
 const BIDARA = {
 	name: bidaraAsst.NAME,
 	config: bidaraAsst.CONFIG,
-	initialMessages: bidaraAsst.INITIAL_MESSAGES,
+	history: bidaraAsst.HISTORY,
 	funcCalling: bidaraFuncCalling,
 	version: bidaraAsst.VERSION,
 

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { DeepChat } from 'deep-chat';
+  import { DeepChat } from 'deep-chat-dev';
   import { setOpenAIKey, cancelThreadRun } from '../utils/openaiUtils';
   import * as threadUtils from '../utils/threadUtils';
 
@@ -45,7 +45,7 @@
     loadedMessages = true;
 
     const messagesToLoad = await threadUtils.loadMessages(threadToLoad.id);
-    messagesToLoad.forEach(( msg ) => { deepChatRef._addMessage(msg)});
+    messagesToLoad.forEach(( msg ) => { deepChatRef.addMessage(msg)});
 
     onLoadComplete();
   }
@@ -58,7 +58,7 @@
     }
   }
 
-  async function onNewMessage(message) { 
+  async function onMessage(message) { 
     if (!deepChatRef || message.isInitial) {
       return
     }
@@ -138,8 +138,8 @@
         currRunId = response.id;
     }
     if (response.object === "list") {
-      if (response.data[0].file_ids.length > 0) {
-        newFileIds = response.data[0].file_ids;
+      if (response.data[0].attachments.length > 0) {
+        newFileIds = response.data[0].attachments.map(attachment => attachment.file_id);
       }
 
       if (shouldProcessImages) {
@@ -164,7 +164,7 @@
 
   async function requestInterceptor(request) {
     if (newFileUploads.length > 0) {
-      newFileIds = request.body.file_ids;
+      newFileIds = request.body.attachments.map(attachment => attachment.file_id);
 
       handleFileUploads(newFileIds, newFileUploads);
     }
@@ -209,11 +209,12 @@
       } : null
     }
   }}
+  history={asst?.history}
   errorMessages={{
     displayServiceErrorMessages: true
   }}
   onError={onError}
-  onNewMessage={onNewMessage}
+  onMessage={onMessage}
   onComponentRender={onComponentRender}
   responseInterceptor={responseInterceptor}
   requestInterceptor={requestInterceptor}
@@ -302,7 +303,6 @@
     },
     placeholder:{text: "How might we..."}
   }}
-  initialMessages={asst?.initialMessages}
   chatStyle={{
     display: "block",
     width: width,

--- a/src/components/AssistantDeepChat.svelte
+++ b/src/components/AssistantDeepChat.svelte
@@ -205,6 +205,7 @@
         new_assistant: asstConfig,
         thread_id: threadId,
         load_thread_history: false,
+        files_tool_type: 'code_interpreter',
         function_handler: handleFuncCalling
       } : null
     }

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -7,12 +7,6 @@ let openaiKey = null;
 function getAssistantConfigFromName(asstName) {
   const asst = assistantOptions.find((opt) => opt.name === asstName);
 
-  if (!asst) {
-    console.log("opts");
-    console.log(assistantOptions);
-    return assistantOptions.find((opt) => opt.name === "BIDARA-TEST").config;
-  }
-
   return asst.config;
 }
 

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -6,6 +6,13 @@ let openaiKey = null;
 
 function getAssistantConfigFromName(asstName) {
   const asst = assistantOptions.find((opt) => opt.name === asstName);
+
+  if (!asst) {
+    console.log("opts");
+    console.log(assistantOptions);
+    return assistantOptions.find((opt) => opt.name === "BIDARA-TEST").config;
+  }
+
   return asst.config;
 }
 
@@ -22,7 +29,7 @@ export async function validAssistant(id, asstName) {
     headers: {
       Authorization: 'Bearer ' + openaiKey,
       'Content-Type': 'application/json',
-      'OpenAI-Beta': 'assistants=v1'
+      'OpenAI-Beta': 'assistants=v2'
     },
     body: null
   });
@@ -49,7 +56,7 @@ export async function updateAssistant(id, config) {
     headers: {
       Authorization: 'Bearer ' + openaiKey,
       'Content-Type': 'application/json',
-      'OpenAI-Beta': 'assistants=v1'
+      'OpenAI-Beta': 'assistants=v2'
     },
     body: JSON.stringify(config)
   });
@@ -71,7 +78,7 @@ export async function createAssistant(config) {
     headers: {
       Authorization: 'Bearer ' + openaiKey,
       'Content-Type': 'application/json',
-      'OpenAI-Beta': 'assistants=v1'
+      'OpenAI-Beta': 'assistants=v2'
     },
     body: JSON.stringify(config)
   });
@@ -93,7 +100,7 @@ export async function getAssistantId(asstName, asstVersion, asstConfig) {
     headers: {
       Authorization: 'Bearer ' + openaiKey,
       'Content-Type': 'application/json',
-      'OpenAI-Beta': 'assistants=v1'
+      'OpenAI-Beta': 'assistants=v2'
     },
     body: null
   });
@@ -217,7 +224,7 @@ export async function validThread(thread_id) {
       headers: {
         Authorization: 'Bearer ' + openaiKey,
         'Content-Type': 'application/json',
-        'OpenAI-Beta': 'assistants=v1'
+        'OpenAI-Beta': 'assistants=v2'
       },
       body: null
     });
@@ -253,7 +260,7 @@ export async function getNewThreadId() {
     headers: {
       Authorization: 'Bearer ' + openaiKey,
       'Content-Type': 'application/json',
-      'OpenAI-Beta': 'assistants=v1'
+      'OpenAI-Beta': 'assistants=v2'
     },
     body: null
   });
@@ -339,7 +346,7 @@ export async function cancelThreadRun(threadId, runId) {
   const method = 'POST';
   const headers = {
     'Authorization': 'Bearer ' + openaiKey,
-    'OpenAI-Beta': 'assistants=v1'
+    'OpenAI-Beta': 'assistants=v2'
   };
 
   const request = {
@@ -371,7 +378,7 @@ export async function getThreadMessages(threadId, limit) {
   const headers = {
     'Authorization': 'Bearer ' + openaiKey,
     'Content-Type': 'application/json',
-    'OpenAI-Beta': 'assistants=v1'
+    'OpenAI-Beta': 'assistants=v2'
   };
 
   const request = {

--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -154,7 +154,7 @@ async function retrieveStoredFiles(threadId) {
 
 async function retrieveNewFiles(threadId, messages, storedFiles) {
   const newFileIds = messages.map((message) => {
-    const fileIds = message.file_ids;
+    const fileIds = message.attachments.map(attachment => attachment.file_id);
 
     const newFileIds = fileIds.filter( (fileId) => message.role !== "user" && !storedFiles.get(fileId));
     return newFileIds;
@@ -246,7 +246,7 @@ async function convertThreadMessagesToMessages(threadId, threadMessages) {
     const role = message.role === "assistant" ? "ai" : message.role;
 
     const content = message.content;
-    const fileIds = message.file_ids;
+    const fileIds = message.attachments.map(attachment => attachment.file_id);
 
     const files = handleAttachments(fileIds, storedFiles.map, newFiles.map);
 


### PR DESCRIPTION
# Upgrade Assistants V2 and Deep-chat Version (dev)
- move to `deep-chat-dev` from `deep-chat`
  - includes several fixes, changes, and updates `deep-chat`'s use of Assistants API to v2
- update our requests/parsing/retrieval to v2

# Update to `deep-chat-dev`
  - fixes:
    - multiple responses
    - file annotations
  - changes:
    -  initial_messages -> history
    - _addMesage -> addMessage
    - onNewMessage -> onMessage
 - v2 API:
   - "retrieval" function becomes "file_search"
   - in request/response interceptors, `file_ids` are now part of `attachments`
   - add `files_tool_type` to `deep-chat` assistant config
     - if not included, defaults to `images`. This means if any images are sent, it defaults to a different format of sending images, and prevents any other file type from being accepted

# Assistants V2
- update all requests including `OpenAI-Beta` header to `"assistants=v2"` from `"assistant=v1"`
- in file retrieval, update where in response to retrieve `file_ids` from (inside of `attachments` instead of top level)