### PR TITLE
Fix Test Assistant

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { Navbar, Sidebar, AssistantDeepChat, Login } from './components';
-  import { assistantOptions } from "./assistant";
+  import { ASSISTANT_OPTIONS, DEFAULT_ASSISTANT } from "./assistant";
   import { getKeyAndThread, getNewAsst } from './utils/openaiUtils';
   import { createBidaraDB, closeBidaraDB } from "./utils/bidaraDB";
   import * as threadUtils from './utils/threadUtils';
@@ -10,8 +10,8 @@
 
   let activeKey = null;
   let activeThread = null;
-  const defaultAsst = assistantOptions[0];
-  let activeAsst = defaultAsst;
+
+  let activeAsst = DEFAULT_ASSISTANT;
   let threads = null;
 
   let loading = true;
@@ -20,7 +20,7 @@
 
   async function initKeyAsstAndThreads() {
 
-    const keyAsstAndThread = await getKeyAndThread(defaultAsst);
+    const keyAsstAndThread = await getKeyAndThread(DEFAULT_ASSISTANT);
 
     if (!keyAsstAndThread[0]) {
       return;
@@ -110,7 +110,7 @@
   }
 
   function getAssistant(asstName) {
-    return assistantOptions.find((opt) => opt.name === asstName);
+    return ASSISTANT_OPTIONS.find((opt) => opt.name === asstName);
   }
 
   async function changeAssistants(newAsst) {
@@ -140,7 +140,7 @@
         bind:chatName={activeThread.name} 
         bind:sidebar={open} 
         bind:currAsst={activeAsst}
-        assistantOptions={assistantOptions}
+        assistantOptions={ASSISTANT_OPTIONS}
         handleRename={renameActiveThread} 
         changeAssistant={changeAssistants}
         />   

--- a/src/assistant/index.js
+++ b/src/assistant/index.js
@@ -1,7 +1,7 @@
 import * as bidaraAsst from './bidara'
 import { funcCalling as bidaraFuncCalling } from './bidaraFunctions'
 
-const BIDARA = {
+const bidara = {
 	name: bidaraAsst.NAME,
 	config: bidaraAsst.CONFIG,
 	initialMessages: bidaraAsst.INITIAL_MESSAGES,
@@ -16,6 +16,10 @@ const BIDARA = {
 	customFunctions: bidaraAsst.FUNCTIONS.filter((func) => func.type === "function"),
 }
 
-export const assistantOptions = [
-	BIDARA,
+export const ASSISTANT_OPTIONS = [
+	bidara,
 ]
+
+const testAssistant = ASSISTANT_OPTIONS.find((asst) => asst.name.includes("TEST"));
+
+export const DEFAULT_ASSISTANT = testAssistant ? testAssistant : ASSISTANT_OPTIONS[0];

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -1,11 +1,16 @@
 import { getStoredAPIKey, setStoredAPIKey } from "./storageUtils";
 import { getActiveThread, getFileByFileId } from "./threadUtils";
-import { assistantOptions } from "../assistant";
+import { ASSISTANT_OPTIONS } from "../assistant";
 
 let openaiKey = null;
 
 function getAssistantConfigFromName(asstName) {
-  const asst = assistantOptions.find((opt) => opt.name === asstName);
+  const asst = ASSISTANT_OPTIONS.find((opt) => opt.name === asstName);
+
+  if (!asst) {
+    return null;
+  }
+
   return asst.config;
 }
 
@@ -180,9 +185,14 @@ export async function getNewAsst(asst, defaultAsst) {
   let asstConfig;
   let name;
   let version;
+
+
   if (asst) {
     name = asst.name;
     asstConfig = getAssistantConfigFromName(name);
+  }
+
+  if (asstConfig) {
     version = /^.*v([0-9]+\.[0-9]+)$/.exec(asstConfig.name)[1];
 
   } else {


### PR DESCRIPTION
# Fix Test Assistant

- if went from e.g. "BIDARA" to "BIDARA-TEST", errored because tried to
find "BIDARA" on load since it was most recent.
- now this will set any assistant with "TEST" in the name to the default
- this means only one assistant should be labeled as "...-TEST" at a
time
- also just changed case of var names for consistency
  - exported consts in caps snake case
  - non exported consts in camel case
  
  Resolves #129 