### PR TITLE
Invalid Thread Error

### DIFF
--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -28,6 +28,12 @@ export async function getActiveThread(defaultAsst) {
     await bidaraDB.setThread(newThread);
     return newThread;
   }
+
+  const isValidThreadId = await validThread(thread.id);
+  if (!isValidThreadId) { // thread is invalid, so new thread with same asst
+    await bidaraDB.deleteThreadById(thread.id);
+    return null;
+  }
   
   let asst = thread.asst;
   if (!asst) { 
@@ -39,14 +45,6 @@ export async function getActiveThread(defaultAsst) {
     asst = await getNewAsst(asst, defaultAsst);
     await setThreadAsst(thread, asst);
     thread.asst = asst;
-  }
-
-  const isValidThreadId = await validThread(thread.id);
-  if (!isValidThreadId) { // thread is invalid, so new thread with same asst
-    const asst = await getNewAsst(null, defaultAsst);
-    const newThread = await createNewThread(asst);
-    await bidaraDB.setThread(newThread);
-    return newThread;
   }
 
   return thread;


### PR DESCRIPTION
# Invalid Thread Error

- when attempting to select a thread that is invalid (likely deleted), causes error and prevents user from selecting other threads
- now checks if thread is valid earlier, and if not changes to recent thread. if no recent thread exists, create a new one.

Resolves #131 