### PR TITLE
IndexedDB Bug

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,7 +3,6 @@
   import { Navbar, Sidebar, AssistantDeepChat, Login } from './components';
   import { ASSISTANT_OPTIONS, DEFAULT_ASSISTANT } from "./assistant";
   import { getKeyAndThread, getNewAsst } from './utils/openaiUtils';
-  import { createBidaraDB, closeBidaraDB } from "./utils/bidaraDB";
   import * as threadUtils from './utils/threadUtils';
   import hljs from "highlight.js";
   window.hljs = hljs;
@@ -47,14 +46,6 @@
 
     loggedIn = true;
   }
-
-  onMount(async () => {
-    await createBidaraDB();
-  });
-
-  onDestroy(async () => {
-    await closeBidaraDB();
-  })
 
   async function newThreadAndSwitch() {
     // If the thread is already "new", stay on it

--- a/src/utils/indexDBUtils.js
+++ b/src/utils/indexDBUtils.js
@@ -1,4 +1,4 @@
-export async function openDB(name, stores, version) {
+export async function createDB(name, stores, version) {
 	return new Promise((resolve, reject) => {
 
 		const request = indexedDB.open(name, version)
@@ -10,6 +10,23 @@ export async function openDB(name, stores, version) {
 				createStore(event, db, store.name, store.primaryKey, store.indices);
 			});
 		};
+
+		request.onsuccess = (event) => {
+			const db = event.target.result;
+			resolve(db);
+		}
+
+		request.onerror = (event) => {
+			const error = event.target.error;
+			reject(error);
+			return;
+		}
+	});
+}
+
+export async function openDB(name, version) {
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.open(name, version)
 
 		request.onsuccess = (event) => {
 			const db = event.target.result;


### PR DESCRIPTION
# IndexedDB Bug

Originally DB was open for the life of the webpage, not being closed until closing the page. While resource requirements aren't a huge deal for this, it was at least bad practice. This also led to the possibility of requests to the DB being sent before it was finished initializing.

These changes properly open and close the DB for each request. Also removes use of DB from `App.svelte` so it won't need to be dealt with anywhere except to make a request.

Resolves #134 