### PR TITLE
Web Search Undefined in Query

### DIFF
--- a/src/assistant/commonFunctions.js
+++ b/src/assistant/commonFunctions.js
@@ -243,8 +243,12 @@ export async function webSearch(params, context) {
     webParams = webParams.parameters;
   }
 
-  const query = webParams.query + " " + webParams.links;
   const links = webParams.links;
+
+  const query = links ?
+    webParams.query + " " + links
+    : webParams.query;
+
 
   const domains = links ? 
     links.map((link) => { 


### PR DESCRIPTION
# Web Search Undefined in Query
- check links given by assistant are defined before add to query

Resolves #154