### PR TITLE
Tag Threads Env (dev/prod)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "svelte-touch-to-mouse": "^1.0.0"
   },
   "scripts": {
-    "build": "rollup -c --bundleConfigAsCjs",
-    "dev": "[ -z \"${SS_KEY}\"  ] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; [ -z \"${PQAI_KEY}\"  ] && echo \"WARN: PQAI_KEY not set. Defaulting to ''\" && export PQAI_KEY=\"\" || set PQAI_KEY=\"\"; [ -z \"${TAV_KEY}\" ] && echo \"WARN: TAV_KEY not set. Defaulting to ''\" && export TAV_KEY=\"\" || set TAV_KEY=\"\"; rollup -c -w --bundleConfigAsCjs",
+    "build": "export ENV=\"prod\" || set ENV=\"prod\"; rollup -c --bundleConfigAsCjs",
+    "dev": "export ENV=\"dev\" || set ENV=\"dev\"; [ -z \"${SS_KEY}\"  ] && echo \"WARN: SS_KEY not set. Defaulting to ''\" && export SS_KEY=\"\" || set SS_KEY=\"\"; [ -z \"${PQAI_KEY}\"  ] && echo \"WARN: PQAI_KEY not set. Defaulting to ''\" && export PQAI_KEY=\"\" || set PQAI_KEY=\"\"; [ -z \"${TAV_KEY}\" ] && echo \"WARN: TAV_KEY not set. Defaulting to ''\" && export TAV_KEY=\"\" || set TAV_KEY=\"\"; rollup -c -w --bundleConfigAsCjs",
     "start": "sirv public"
   },
   "keywords": [],

--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -1,6 +1,7 @@
 import { getStoredAPIKey, setStoredAPIKey } from "./storageUtils";
 import { getActiveThread, getFileByFileId } from "./threadUtils";
 import { ASSISTANT_OPTIONS } from "../assistant";
+import { ENV } from "process.env";
 
 let openaiKey = null;
 
@@ -258,6 +259,14 @@ export async function getNewThreadId() {
   if (!openaiKey) {
     throw new Error('openai key not set. cannot get new thread.');
   }
+
+  const metadata = {
+    "env": ENV
+  }
+
+  const body = {
+    metadata
+  }
   const response = await fetch("https://api.openai.com/v1/threads", {
     method: "POST",
     headers: {
@@ -265,7 +274,7 @@ export async function getNewThreadId() {
       'Content-Type': 'application/json',
       'OpenAI-Beta': 'assistants=v2'
     },
-    body: null
+    body: JSON.stringify(body)
   });
 
   const r = await response.json();


### PR DESCRIPTION
# Tag Threads Env (dev/prod)
- add metadata tag for env to new threads, which will allow deleting all test/dev threads
```
thread = {
  metadata: {
    "env": "<prod | dev>"
  },
  ...
}
```
- can be used with updated [oait](https://github.com/jackitaliano/oait) +v0.0.9 (update via `brew upgrade oait`)
  - `oait threads get -s <session-key> -m "env=dev"`
  - `oait threads del -s <session-key> -m "env=dev"`

Could in future make a small script in actions that runs periodically to call this as a cleanup.

Resolves #157 

## Changes
### Build (`package.json`)
- build script sets environment variable "ENV" to "prod"
- dev script sets environment variable "ENV" to "dev"

### Threads (`openaiUtils.json`)
- add metadata to new threads request for env var "env"