### PR TITLE
Fix Deleted Thread Bug

### DIFF
--- a/src/utils/threadUtils.js
+++ b/src/utils/threadUtils.js
@@ -32,7 +32,17 @@ export async function getActiveThread(defaultAsst) {
   const isValidThreadId = await validThread(thread.id);
   if (!isValidThreadId) { // thread is invalid, so new thread with same asst
     await bidaraDB.deleteThreadById(thread.id);
-    return null;
+    const recentThread = await getRecentThread();
+
+    if (recentThread === null) {
+      const asst = await getNewAsst(null, defaultAsst);
+      const newThread = await createNewThread(asst);
+      await bidaraDB.setThread(newThread);
+      return newThread;
+    }
+
+    await setActiveThread(null, recentThread.id);
+    return await getActiveThread(defaultAsst);
   }
   
   let asst = thread.asst;


### PR DESCRIPTION
# Fix Deleted Thread Bug

## Bug
Checks to verify threads are valid before displaying to user. However, in some cases when multiple threads were deleted, this logic would fail. Would always fail if loading from login page.
![image](https://github.com/nasa-petal/bidara-deep-chat/assets/93797825/06c1b878-e983-4d8d-956d-c4a4bdc7f336)


## Solution
If thread current active thread is not valid, get recent thread and check again. If that is not valid, repeat until either a valid thread is found, or all threads have been deleted. If a valid thread is found, yield that thread, otherwise create a new one.