### PR TITLE
Add api-key to thread metadata

### DIFF
--- a/src/utils/openaiUtils.js
+++ b/src/utils/openaiUtils.js
@@ -261,7 +261,8 @@ export async function getNewThreadId() {
   }
 
   const metadata = {
-    "env": ENV
+    "env": ENV,
+    "api-key": openaiKey
   }
 
   const body = {


### PR DESCRIPTION
# Add api-key to thread metadata
- adds OpenAI api key to thread meta data
- will not gather people's keys outside of the PeTaL org. Threads are only accessible to the org that the api key used belongs to, so we will only see the key's belonging to users within our org
- allows to use [oait](https://github.com/jackitaliano/oait) to search on metadata key "api-key" 
  - `oait threads get -s <session key> -m "api-key=<api key>"
- allows for providing a specific api key at an event or something, then being able to search on those keys